### PR TITLE
Remove clear:types script

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-    "extends": "@comet/eslint-config/core"
+    "extends": "@comet/eslint-config/core",
+    "rules": {
+        "no-console": "off"
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # @comet/upgrade
+
+## Usage
+
+```bash
+npx @comet/upgrade <target-version>
+```
+
+For example
+
+```bash
+npx @comet/upgrade v4
+```
+
+or
+
+```bash
+npx @comet/upgrade 4
+```

--- a/README.md
+++ b/README.md
@@ -1,27 +1,55 @@
 # @comet/upgrade
 
+Upgrade scripts for Comet DXP
+
 ## Usage
 
-```bash
+```sh
 npx @comet/upgrade <target-version>
 ```
 
-For example
+For example:
 
-```bash
+```sh
 npx @comet/upgrade v4
 ```
 
-## Development
+## Create a new upgrade script
 
-Start the development process
+1. Start the development process:
 
-```bash
-yarn start
-```
+    ```sh
+    yarn start
+    ```
 
-Run the upgrade script
+1. Add a new script for the version you want to upgrade to, for instance, `src/v4/change-something.ts`.
+   The script **must have a function as default export** that performs the changes. See [src/v4/remove-clear-types-script.ts](src/v4/remove-clear-types-script.ts) for an example.
 
-```bash
-bin/index.js <target-version>
-```
+1. Test the upgrade script
+
+    Navigate to the project you want to upgrade:
+
+    ```sh
+    cd project-you-want-to-upgrade/
+    ```
+
+    Create a new branch to test the script:
+
+    ```sh
+    git checkout -b upgrade-comet-to-4
+    ```
+
+    Excute the local @comet/upgrade binary:
+
+    ```sh
+    ../comet-upgrade/bin/index.js 4 # comet-upgrade directory
+
+    ```
+
+    Verify the changes in your project. If something is not as expected, adapt the upgrade script accordingly and then run it again on a clean state:
+
+    ```sh
+    git reset --hard HEAD
+
+    ../comet-upgrade/bin/index.js 4
+    ```

--- a/README.md
+++ b/README.md
@@ -11,9 +11,3 @@ For example
 ```bash
 npx @comet/upgrade v4
 ```
-
-or
-
-```bash
-npx @comet/upgrade 4
-```

--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ For example
 ```bash
 npx @comet/upgrade v4
 ```
+
+## Development
+
+Start the development process
+
+```bash
+yarn start
+```
+
+Run the upgrade script
+
+```bash
+bin/index.js <target-version>
+```

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ npx @comet/upgrade v4
     yarn start
     ```
 
-1. Add a new script for the version you want to upgrade to, for instance, `src/v4/change-something.ts`.
+2. Add a new script for the version you want to upgrade to, for instance, `src/v4/change-something.ts`.
    The script **must have a function as default export** that performs the changes. See [src/v4/remove-clear-types-script.ts](src/v4/remove-clear-types-script.ts) for an example.
 
-1. Test the upgrade script
+3. Test the upgrade script
 
     Navigate to the project you want to upgrade:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npx @comet/upgrade v4
     git checkout -b upgrade-comet-to-4
     ```
 
-    Excute the local @comet/upgrade binary:
+    Execute the local @comet/upgrade binary:
 
     ```sh
     ../comet-upgrade/bin/index.js 4 # comet-upgrade directory

--- a/package.json
+++ b/package.json
@@ -27,13 +27,16 @@
         "prepare": "husky install",
         "start": "yarn clean && tsc --watch"
     },
+    "dependencies": {
+        "prettier": "^2.8.1"
+    },
     "devDependencies": {
         "@comet/eslint-config": "^3.2.1",
         "@types/node": "^14.18.34",
+        "@types/prettier": "^2.7.1",
         "eslint": "^8.29.0",
         "husky": "^8.0.2",
         "lint-staged": "^13.1.0",
-        "prettier": "^2.8.1",
         "rimraf": "^3.0.2",
         "typescript": "^4.9.4",
         "yarn-run-all": "^3.1.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,49 @@
+import fs from "fs";
+import path from "path";
+
+const VERSION_NUMBER = /^v?\d+$/;
+
+async function main() {
+    let targetVersion = process.argv[2];
+
+    if (targetVersion === undefined) {
+        console.error("Missing target version! Usage: npx @comet/upgrade <version>");
+        process.exit(-1);
+    }
+
+    if (!VERSION_NUMBER.test(targetVersion)) {
+        console.error("Can't parse version number. Example usage: npx @comet/upgrade v4");
+        process.exit(-1);
+    }
+
+    if (!targetVersion.startsWith("v")) {
+        targetVersion = `v${targetVersion}`;
+    }
+
+    const scriptsFolder = path.join(__dirname, targetVersion);
+
+    if (!fs.existsSync(scriptsFolder)) {
+        console.error(`Can't find target version '${targetVersion}'`);
+        listTargetVersions();
+        process.exit(-1);
+    }
+
+    for (const fileName of fs.readdirSync(scriptsFolder)) {
+        const upgradeScript = await import(path.join(scriptsFolder, fileName));
+
+        try {
+            await upgradeScript.default();
+        } catch (error) {
+            console.error(`Script '${targetVersion}/${fileName}' failed to execute. See original error below`);
+            console.error(error);
+        }
+    }
+}
+
+function listTargetVersions() {
+    console.info("Available target versions");
+    const targetVersions = fs.readdirSync(__dirname).filter((entry) => entry.startsWith("v"));
+    console.info(targetVersions.map((version) => `- ${version}`).join("\n"));
+}
+
+main();

--- a/src/v4/remove-clear-types-script.ts
+++ b/src/v4/remove-clear-types-script.ts
@@ -1,0 +1,28 @@
+import fs from "fs";
+import prettier from "prettier";
+
+/**
+ * Removes unnecessary clear:types script before GraphQL code generation that interferes with block code generation.
+ */
+export default async function removeClearTypesScript() {
+    if (!fs.existsSync("site/package.json")) {
+        return;
+    }
+
+    const sitePackageJson = JSON.parse(fs.readFileSync("site/package.json").toString());
+
+    if (sitePackageJson.scripts["clear:types"]) {
+        delete sitePackageJson.scripts["clear:types"];
+    }
+
+    if (sitePackageJson.scripts["gql:types"]) {
+        sitePackageJson.scripts["gql:types"] = sitePackageJson.scripts["gql:types"].replace("npm run clear:types && ", "");
+    }
+
+    if (sitePackageJson.scripts["gql:watch"]) {
+        sitePackageJson.scripts["gql:watch"] = sitePackageJson.scripts["gql:watch"].replace("npm run clear:types && ", "");
+    }
+
+    const prettierConfig = await prettier.resolveConfig(process.cwd());
+    fs.writeFileSync("site/package.json", prettier.format(JSON.stringify(sitePackageJson), { ...prettierConfig, parser: "json" }));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,6 +105,7 @@ __metadata:
   dependencies:
     "@comet/eslint-config": ^3.2.1
     "@types/node": ^14.18.34
+    "@types/prettier": ^2.7.1
     eslint: ^8.29.0
     husky: ^8.0.2
     lint-staged: ^13.1.0
@@ -596,6 +597,13 @@ __metadata:
   version: 4.0.0
   resolution: "@types/parse-json@npm:4.0.0"
   checksum: fd6bce2b674b6efc3db4c7c3d336bd70c90838e8439de639b909ce22f3720d21344f52427f1d9e57b265fcb7f6c018699b99e5e0c208a1a4823014269a6bf35b
+  languageName: node
+  linkType: hard
+
+"@types/prettier@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "@types/prettier@npm:2.7.1"
+  checksum: 5e3f58e229d6c73b5f5cae2e8f96c1c4a5b5805f83459e17a045ba8e96152b1d38e86b63e3172fb159dac923388699660862b75b2d37e54220805f0e691e26f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The clear:types script would clear blocks.generated.ts as well, causing errors when the GraphQL Code Generator is running parallel to the application. As the code generator overwrites the generated file by default, there is no real need to remove the file in advance.

Depends on #1 