### PR TITLE
v7: Import admin theme types in vendors.d.ts

### DIFF
--- a/src/v7/import-admin-theme-types.ts
+++ b/src/v7/import-admin-theme-types.ts
@@ -1,0 +1,21 @@
+import { readFile, writeFile } from "fs/promises";
+
+import { formatCode } from "../util/format-code.util";
+
+/**
+ * Imports types from `@comet/admin-theme` in vendors.d.ts to allow using custom theme variants and colors
+ */
+export default async function importAdminThemeTypes() {
+    const filePath = "admin/src/vendors.d.ts";
+
+    let fileContent = (await readFile(filePath)).toString();
+
+    if (fileContent.includes('<reference types="@comet/admin-theme" />')) {
+        return;
+    }
+
+    fileContent = `/// <reference types="@comet/admin-theme" />
+    
+    ${fileContent}`;
+    await writeFile(filePath, await formatCode(fileContent, filePath));
+}

--- a/src/v7/import-admin-theme-types.ts
+++ b/src/v7/import-admin-theme-types.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { readFile, writeFile } from "fs/promises";
 
 import { formatCode } from "../util/format-code.util";
@@ -7,15 +8,20 @@ import { formatCode } from "../util/format-code.util";
  */
 export default async function importAdminThemeTypes() {
     const filePath = "admin/src/vendors.d.ts";
+    const typeReference = '/// <reference types="@comet/admin-theme" />';
 
-    let fileContent = (await readFile(filePath)).toString();
+    let fileContent = "";
+    if (fs.existsSync(filePath)) {
+        fileContent = (await readFile(filePath)).toString();
+    }
 
-    if (fileContent.includes('<reference types="@comet/admin-theme" />')) {
+    if (fileContent.includes(typeReference)) {
         return;
     }
 
-    fileContent = `/// <reference types="@comet/admin-theme" />
+    fileContent = `${typeReference}
     
     ${fileContent}`;
+
     await writeFile(filePath, await formatCode(fileContent, filePath));
 }


### PR DESCRIPTION
Enables the usage of custom theme extensions like the highlight colors from https://github.com/vivid-planet/comet/pull/1840