### PR TITLE
v7: Disable GraphQL field suggestions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
                 "eslint": "^8.56.0",
                 "glob": "^10.3.10",
                 "prettier": "^2.8.1",
-                "semver": "^7.3.8"
+                "semver": "^7.3.8",
+                "ts-morph": "^22.0.0"
             },
             "bin": {
                 "upgrade": "bin/index.js"
@@ -888,6 +889,39 @@
             "integrity": "sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==",
             "dev": true
         },
+        "node_modules/@ts-morph/common": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.23.0.tgz",
+            "integrity": "sha512-m7Lllj9n/S6sOkCkRftpM7L24uvmfXQFedlW/4hENcuJH1HHm9u5EgxZb9uVjQSCGrbBWBkOGgcTxNg36r6ywA==",
+            "dependencies": {
+                "fast-glob": "^3.3.2",
+                "minimatch": "^9.0.3",
+                "mkdirp": "^3.0.1",
+                "path-browserify": "^1.0.1"
+            }
+        },
+        "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@ts-morph/common/node_modules/minimatch": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+            "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/@types/eslint": {
             "version": "8.56.2",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.2.tgz",
@@ -1491,7 +1525,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
             "dependencies": {
                 "fill-range": "^7.0.1"
             },
@@ -1606,6 +1639,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/code-block-writer": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.1.tgz",
+            "integrity": "sha512-c5or4P6erEA69TxaxTNcHUNcIn+oyxSRTOWV+pSYF+z4epXqNvwvJ70XPGjPNgue83oAFAPBRQYwpAJ/Hpe/Sg=="
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -2592,7 +2630,6 @@
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
             "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-            "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -2608,7 +2645,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -2649,7 +2685,6 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -3391,7 +3426,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -4004,7 +4038,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -4030,7 +4063,6 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
             "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-            "dev": true,
             "dependencies": {
                 "braces": "^3.0.2",
                 "picomatch": "^2.3.1"
@@ -4098,6 +4130,20 @@
             "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/mkdirp": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+            "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+            "bin": {
+                "mkdirp": "dist/cjs/src/bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/ms": {
@@ -4600,6 +4646,11 @@
                 "tslib": "^2.0.3"
             }
         },
+        "node_modules/path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4658,7 +4709,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -5524,12 +5574,20 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
             "engines": {
                 "node": ">=8.0"
+            }
+        },
+        "node_modules/ts-morph": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-22.0.0.tgz",
+            "integrity": "sha512-M9MqFGZREyeb5fTl6gNHKZLqBQA0TjA1lea+CR48R8EBTDuWrNqW6ccC5QvjNR4s6wDumD3LTCjOFSp9iwlzaw==",
+            "dependencies": {
+                "@ts-morph/common": "~0.23.0",
+                "code-block-writer": "^13.0.1"
             }
         },
         "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "eslint": "^8.56.0",
         "glob": "^10.3.10",
         "prettier": "^2.8.1",
-        "semver": "^7.3.8"
+        "semver": "^7.3.8",
+        "ts-morph": "^22.0.0"
     },
     "devDependencies": {
         "@comet/eslint-config": "^3.2.1",

--- a/src/v7/hide-graphql-field-suggestions.ts
+++ b/src/v7/hide-graphql-field-suggestions.ts
@@ -20,11 +20,8 @@ export default async function hideGraphqlFieldSuggestions() {
         moduleSpecifier: "@nestjs/apollo",
     });
 
-    // Get the AppModule class
-    const appModuleClass = sourceFile.getClassOrThrow("AppModule");
-
     // Get the forRoot method within AppModule
-    const forRootMethod = appModuleClass.getMethodOrThrow("forRoot");
+    const forRootMethod = sourceFile.getClassOrThrow("AppModule").getMethodOrThrow("forRoot");
 
     // Get the GraphQLModule.forRootAsync call within the forRoot method
     const graphqlForRootCall = forRootMethod

--- a/src/v7/hide-graphql-field-suggestions.ts
+++ b/src/v7/hide-graphql-field-suggestions.ts
@@ -50,10 +50,9 @@ export default async function hideGraphqlFieldSuggestions() {
 
     // return if property formatError already exists
     if (graphqlForRootCall.getArguments().find((arg) => arg.getText().includes("formatError"))) {
-        console.warn(
-            `WARNING: formatError property already exists in GraphQLModule.forRootAsync options. To be sure GraphQl field suggestions are disabled for non dev environments, please check if the implementation already contains: ${formatErrorImplText}`,
+        throw new Error(
+            `formatError property already exists in GraphQLModule.forRootAsync options. To be sure GraphQl field suggestions are disabled for non dev environments, please check if the implementation already contains: ${formatErrorImplText}`,
         );
-        return;
     }
 
     // Find the useFactory function within the GraphQLModule.forRootAsync call

--- a/src/v7/hide-graphql-field-suggestions.ts
+++ b/src/v7/hide-graphql-field-suggestions.ts
@@ -1,0 +1,83 @@
+import { Project, SyntaxKind } from "ts-morph";
+
+/**
+ * Adds the `formatError` property to `GraphQLModule` options to hide `GraphQL` field suggestions for non dev environments.
+ */
+export default async function hideGraphqlFieldSuggestions() {
+    const project = new Project({ tsConfigFilePath: "./api/tsconfig.json" });
+
+    const sourceFile = project.getSourceFile("api/src/app.module.ts");
+    if (!sourceFile) throw new Error("app.module.ts not found");
+
+    // Add the required import statements
+    sourceFile.addImportDeclaration({
+        namedImports: ["ValidationError"],
+        moduleSpecifier: "apollo-server-express",
+    });
+
+    sourceFile.addImportDeclaration({
+        namedImports: ["ApolloDriverConfig"],
+        moduleSpecifier: "@nestjs/apollo",
+    });
+
+    // Get the AppModule class
+    const appModuleClass = sourceFile.getClassOrThrow("AppModule");
+
+    // Get the forRoot method within AppModule
+    const forRootMethod = appModuleClass.getMethodOrThrow("forRoot");
+
+    // Get the GraphQLModule.forRootAsync call within the forRoot method
+    const graphqlForRootCall = forRootMethod
+        .getBody()
+        ?.getDescendantsOfKind(SyntaxKind.CallExpression)
+        .find((call) => call.getText().includes("GraphQLModule.forRootAsync"));
+    if (!graphqlForRootCall) throw new Error("GraphQLModule.forRootAsync call not found within forRoot method.");
+
+    // Add the generic type ApolloDriverConfig to the GraphQLModule.forRootAsync call
+    if (!forRootMethod.getFullText().includes("GraphQLModule.forRootAsync<ApolloDriverConfig>")) {
+        const expression = graphqlForRootCall.getExpression();
+        if (!expression) throw new Error("Expression not found within GraphQLModule.forRootAsync call.");
+        const expressionText = expression.getText();
+        expression.replaceWithText(expressionText.replace(`${expressionText}`, `${expressionText}<ApolloDriverConfig>`));
+    }
+
+    const formatErrorImplText = `
+        (error) => {
+            if (process.env.NODE_ENV !== "development") {
+                if (error instanceof ValidationError) {
+                    return new ValidationError("Invalid request.");
+                }
+            }
+            return error;
+        }`;
+
+    // return if property formatError already exists
+    if (graphqlForRootCall.getArguments().find((arg) => arg.getText().includes("formatError"))) {
+        console.warn(
+            `WARNING: formatError property already exists in GraphQLModule.forRootAsync options. To be sure GraphQl field suggestions are disabled for non dev environments, please check if the implementation already contains: ${formatErrorImplText}`,
+        );
+        return;
+    }
+
+    // Find the useFactory function within the GraphQLModule.forRootAsync call
+    const useFactoryFunction = graphqlForRootCall.getFirstDescendantByKindOrThrow(
+        SyntaxKind.ArrowFunction,
+        "useFactory function not found within GraphQLModule.forRootAsync call.",
+    );
+    if (!useFactoryFunction.getParent().getText().includes("useFactory"))
+        throw new Error("useFactory function not found within GraphQLModule.forRootAsync call.");
+
+    // Find the object literal being returned by the useFactory function
+    const returnObjectLiteral = useFactoryFunction.getFirstDescendantByKindOrThrow(
+        SyntaxKind.ObjectLiteralExpression,
+        "Object literal not found within useFactory function.",
+    );
+
+    // Add your formatError to GraphQLModule.forRootAsync options
+    returnObjectLiteral.addPropertyAssignment({
+        name: "formatError",
+        initializer: ({ write }) => write(formatErrorImplText),
+    });
+
+    sourceFile.saveSync();
+}


### PR DESCRIPTION
Updates `app.module.ts` to disable GraphQL field suggestions in production. The added property looks like this:

```ts
// ...
formatError: (error) => {
    // Disable GraphQL field suggestions in production
    if (process.env.NODE_ENV !== "development") {
        if (error instanceof ValidationError) {
            return new ValidationError("Invalid request.");
        }
    }
    return error;
},
// ...
```

It also adds the type `ApolloDriverConfig` as generic to the `GraphQLModule.forRootAsync` to improve typing.

---

COM-493