### PR TITLE
Fix hide-graphql-field-suggestions script

### DIFF
--- a/src/v7/hide-graphql-field-suggestions.ts
+++ b/src/v7/hide-graphql-field-suggestions.ts
@@ -72,7 +72,7 @@ export default async function hideGraphqlFieldSuggestions() {
     // Add your formatError to GraphQLModule.forRootAsync options
     returnObjectLiteral.addPropertyAssignment({
         name: "formatError",
-        initializer: ({ write }) => write(formatErrorImplText),
+        initializer: formatErrorImplText,
     });
 
     sourceFile.saveSync();


### PR DESCRIPTION
Currently, the script causes this somewhat cryptic error:

```ts
Script 'v7/hide-graphql-field-suggestions.js' failed to execute. See original error below
TypeError: Cannot read properties of undefined (reading '_newLineIfNewLineOnNextWrite')
    at write (comet-upgrade/node_modules/code-block-writer/script/mod.js:394:14)
    at initializer (comet-upgrade/lib/v7/hide-graphql-field-suggestions.js:80:24)
```

This error happens within the `write` method so it may be a bug in ts-morph.

However, adding `formatError` to the file also works without the write method by directly passing the string to initializer. That's what I did