### PR TITLE
Allow upgrading to any version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "eslint": "^8.56.0",
                 "glob": "^10.3.10",
                 "prettier": "^2.8.1",
-                "semver": "^7.3.8",
+                "semver": "^7.6.2",
                 "ts-morph": "^22.0.0"
             },
             "bin": {
@@ -22,7 +22,7 @@
                 "@comet/eslint-config": "^3.2.1",
                 "@types/node": "^20.0.0",
                 "@types/prettier": "^2.7.1",
-                "@types/semver": "^7.3.13",
+                "@types/semver": "^7.5.8",
                 "husky": "^8.0.2",
                 "lint-staged": "^13.1.0",
                 "npm-run-all": "^4.1.5",
@@ -978,9 +978,9 @@
             "dev": true
         },
         "node_modules/@types/semver": {
-            "version": "7.5.6",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
-            "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
             "dev": true
         },
         "node_modules/@types/websocket": {
@@ -5077,25 +5077,11 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
             "bin": {
                 "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/semver/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dependencies": {
-                "yallist": "^4.0.0"
             },
             "engines": {
                 "node": ">=10"
@@ -6031,11 +6017,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yaml": {
             "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
         "eslint": "^8.56.0",
         "glob": "^10.3.10",
         "prettier": "^2.8.1",
-        "semver": "^7.3.8",
+        "semver": "^7.6.2",
         "ts-morph": "^22.0.0"
     },
     "devDependencies": {
         "@comet/eslint-config": "^3.2.1",
         "@types/node": "^20.0.0",
         "@types/prettier": "^2.7.1",
-        "@types/semver": "^7.3.13",
+        "@types/semver": "^7.5.8",
         "husky": "^8.0.2",
         "lint-staged": "^13.1.0",
         "npm-run-all": "^4.1.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ async function updateDependencies(targetVersion: SemVer) {
             "--no-audit",
             "--loglevel",
             "error",
+            targetVersion.prerelease.length > 0 ? "--save-exact" : "",
             ...dependencies.map((dependency) => `${dependency}@${targetVersion.version}`),
             ...devDependencies.map((dependency) => `${dependency}@${targetVersion.version}`),
         ]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 import fs from "fs";
 import path from "path";
-import semver from "semver";
+import semver, { SemVer } from "semver";
 
 import { executeCommand } from "./util/execute-command.util";
 
-const VERSION_NUMBER = /^v?\d+$/;
 const microservices = ["api", "admin", "site"] as const;
 
 function microserviceExists(microservice: "api" | "admin" | "site") {
@@ -12,28 +11,26 @@ function microserviceExists(microservice: "api" | "admin" | "site") {
 }
 
 async function main() {
-    let targetVersionArg = process.argv[2];
+    const targetVersionArg = process.argv[2];
 
     if (targetVersionArg === undefined) {
         console.error("Missing target version! Usage: npx @comet/upgrade <version>");
         process.exit(-1);
     }
 
-    if (!VERSION_NUMBER.test(targetVersionArg)) {
+    const targetVersion = semver.coerce(targetVersionArg, { includePrerelease: true });
+
+    if (!targetVersion) {
         console.error("Can't parse version number. Example usage: npx @comet/upgrade v4");
         process.exit(-1);
     }
 
-    if (targetVersionArg.startsWith("v")) {
-        targetVersionArg = targetVersionArg.substring(1);
-    }
+    const targetVersionFolder = `v${targetVersion.major}`;
 
-    const targetVersion = Number(targetVersionArg);
-
-    const scriptsFolder = path.join(__dirname, `v${targetVersion}`);
+    const scriptsFolder = path.join(__dirname, targetVersionFolder);
 
     if (!fs.existsSync(scriptsFolder)) {
-        console.error(`Can't find target version 'v${targetVersionArg}'`);
+        console.error(`Can't find upgrade scripts for target version '${targetVersionFolder}'`);
         listTargetVersions();
         process.exit(-1);
     }
@@ -45,7 +42,7 @@ async function main() {
     console.info("Updating dependencies");
     await updateDependencies(targetVersion);
 
-    await runUpgradeScripts(targetVersion);
+    await runUpgradeScripts(targetVersionFolder);
 
     await runEslintFix();
 }
@@ -83,7 +80,7 @@ function getCurrentVersion() {
     return semver.major(version);
 }
 
-async function updateDependencies(targetVersion: number) {
+async function updateDependencies(targetVersion: SemVer) {
     const packages: Record<(typeof microservices)[number], string[]> = {
         api: ["@comet/blocks-api", "@comet/cms-api"],
         admin: [
@@ -126,14 +123,14 @@ async function updateDependencies(targetVersion: number) {
             "--no-audit",
             "--loglevel",
             "error",
-            ...dependencies.map((dependency) => `${dependency}@${targetVersion}`),
-            ...devDependencies.map((dependency) => `${dependency}@${targetVersion}`),
+            ...dependencies.map((dependency) => `${dependency}@${targetVersion.version}`),
+            ...devDependencies.map((dependency) => `${dependency}@${targetVersion.version}`),
         ]);
     }
 }
 
-async function runUpgradeScripts(targetVersion: number) {
-    const scriptsFolder = path.join(__dirname, `v${targetVersion}`);
+async function runUpgradeScripts(targetVersionFolder: string) {
+    const scriptsFolder = path.join(__dirname, targetVersionFolder);
 
     for (const fileName of fs.readdirSync(scriptsFolder)) {
         const upgradeScript = await import(path.join(scriptsFolder, fileName));
@@ -141,7 +138,7 @@ async function runUpgradeScripts(targetVersion: number) {
         try {
             await upgradeScript.default();
         } catch (error) {
-            console.error(`Script 'v${targetVersion}/${fileName}' failed to execute. See original error below`);
+            console.error(`Script '${targetVersionFolder}/${fileName}' failed to execute. See original error below`);
             console.error(error);
         }
     }


### PR DESCRIPTION
Using the semver package instead of a regex for the version number allows us to upgrade to any valid version, e.g., a beta release.