### PR TITLE
Fix single script run

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,15 @@ async function main() {
         process.exit(-1);
     }
 
-    const isUpgradeScript = fs.existsSync(path.join(__dirname, targetVersionArg.replace(/\.ts$/, ".js")));
+    const isUpgradeScript = targetVersionArg.endsWith(".ts");
 
     if (isUpgradeScript) {
-        await runUpgradeScript(targetVersionArg.replace(/\.ts$/, ".js"));
+        if (fs.existsSync(path.join(__dirname, targetVersionArg.replace(/\.ts$/, ".js")))) {
+            await runUpgradeScript(targetVersionArg.replace(/\.ts$/, ".js"));
+        } else {
+            console.error(`Can't find upgrade script '${targetVersionArg}'`);
+            process.exit(-1);
+        }
         return;
     }
 


### PR DESCRIPTION
The single script run check incorrectly matched for "v7" since the folder exists. We fix this by checking if the argument ends with ".ts". We furthermore add an error message if the script doesn't exist.