### PR TITLE
Add `@comet/eslint-plugin` to dependencies to update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ async function updateDependencies(targetVersion: SemVer) {
 
         const dependencies = packages[microservice].filter((packageName) => packageJson.dependencies?.[packageName] !== undefined);
 
-        const devDependencies = ["@comet/cli", "@comet/eslint-config"].filter(
+        const devDependencies = ["@comet/cli", "@comet/eslint-config", "@comet/eslint-plugin"].filter(
             (packageName) => packageJson.devDependencies?.[packageName] !== undefined,
         );
 


### PR DESCRIPTION
The package was added to the package.json in the Starter some time ago. To ensure we have the same minor version of all Comet packages, we should update it as well.