### PR TITLE
Add support for running upgrade script before updating dependencies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,12 @@ async function main() {
 
     if (isUpgradeScript) {
         if (fs.existsSync(path.join(__dirname, targetVersionArg.replace(/\.ts$/, ".js")))) {
-            await runUpgradeScript(targetVersionArg.replace(/\.ts$/, ".js"));
+            const module = await import(path.join(__dirname, targetVersionArg.replace(/\.ts$/, ".js")));
+            await runUpgradeScript({
+                name: targetVersionArg,
+                stage: "before-install",
+                script: module.default,
+            });
         } else {
             console.error(`Can't find upgrade script '${targetVersionArg}'`);
             process.exit(-1);
@@ -51,10 +56,16 @@ async function main() {
 
     console.info(`Upgrading from v${currentVersion} to v${targetVersion}`);
 
+    const upgradeScripts = await findUpgradeScripts(targetVersionFolder);
+
+    const beforeInstallScripts = upgradeScripts.filter((script) => script.stage === "before-install");
+    await runUpgradeScripts(beforeInstallScripts);
+
     console.info("Updating dependencies");
     await updateDependencies(targetVersion);
 
-    await runUpgradeScripts(targetVersionFolder);
+    const afterInstallScripts = upgradeScripts.filter((script) => script.stage === "after-install");
+    await runUpgradeScripts(afterInstallScripts);
 
     await runEslintFix();
 }
@@ -142,21 +153,41 @@ async function updateDependencies(targetVersion: SemVer) {
     }
 }
 
-async function runUpgradeScripts(targetVersionFolder: string) {
+type UpgradeScript = {
+    name: string;
+    stage: "before-install" | "after-install";
+    script: () => Promise<void>;
+};
+
+async function findUpgradeScripts(targetVersionFolder: string): Promise<UpgradeScript[]> {
+    const scripts: UpgradeScript[] = [];
+
     const scriptsFolder = path.join(__dirname, targetVersionFolder);
 
     for (const fileName of fs.readdirSync(scriptsFolder)) {
-        await runUpgradeScript(path.join(targetVersionFolder, fileName));
+        const module = await import(path.join(__dirname, targetVersionFolder, fileName));
+
+        scripts.push({
+            name: fileName,
+            stage: module.stage ?? "after-install",
+            script: module.default,
+        });
+    }
+
+    return scripts;
+}
+
+async function runUpgradeScripts(scripts: UpgradeScript[]) {
+    for (const script of scripts) {
+        await runUpgradeScript(script);
     }
 }
 
-async function runUpgradeScript(script: string) {
-    const upgradeScript = await import(path.join(__dirname, script));
-
+async function runUpgradeScript(script: UpgradeScript) {
     try {
-        await upgradeScript.default();
+        await script.script();
     } catch (error) {
-        console.error(`Script '${script}' failed to execute. See original error below`);
+        console.error(`Script '${script.name}' failed to execute. See original error below`);
         console.error(error);
     }
 }

--- a/src/v8/remove-blocks-packages.ts
+++ b/src/v8/remove-blocks-packages.ts
@@ -1,0 +1,12 @@
+import { existsSync } from "fs";
+import { readFile, writeFile } from "fs/promises";
+
+export const stage = "before-install";
+
+export default async function removeBlocksPackages() {
+    if (existsSync("api/package.json")) {
+        let fileContent = (await readFile("api/package.json")).toString();
+        fileContent = fileContent.replace(/\n\s*"@comet\/blocks-api".*$/m, "");
+        await writeFile("api/package.json", fileContent);
+    }
+}


### PR DESCRIPTION
## Motivation

With Comet v8 we will remove the `@comet/blocks-api` and `@comet/blocks-admin` packages. These packages have to be removed from the corresponding package.json files before updating the dependencies, as there would be an install error due to the missing packages otherwise.

## Solution

Introduce the concept of stages (could also be called hooks or similar) that allows an upgrade script to define when it should be executed. The stage can be defined by exporting a magic constant `stage` (similar to what Next does with `dynamic`). If not supplied, the default stage will be `after-install`.

## Example

```ts
// Script should be run before installing dependencies
export const stage = "before-install";

export default async function upgradeScript() {
    // Perform some actions before installing dependencies
}
```