### PR TITLE
Prevent installing the npm package `undefined` 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ async function updateDependencies(targetVersion: SemVer) {
             "--no-audit",
             "--loglevel",
             "error",
-            targetVersion.prerelease.length > 0 ? "--save-exact" : "",
+            ...(targetVersion.prerelease.length > 0 ? ["--save-exact"] : []),
             ...dependencies.map((dependency) => `${dependency}@${targetVersion.version}`),
             ...devDependencies.map((dependency) => `${dependency}@${targetVersion.version}`),
         ]);


### PR DESCRIPTION
## Problem

The npm package [undefined](https://www.npmjs.com/package/undefined) was installed in projects when executing the upgrade script

<img width="376" alt="Bildschirmfoto 2024-11-08 um 12 45 34" src="https://github.com/user-attachments/assets/eb2cad1c-2787-4f78-8568-7a7d27c9c7db">


## Reason

If it was a non-prelease version, an empty string was added to the npm install command. This was interpreted as `undefined` which was then converted to a string, causing npm to install the package.

<img width="257" alt="Bildschirmfoto 2024-11-08 um 12 45 40" src="https://github.com/user-attachments/assets/9e566f0f-f89d-42cf-97ce-a1e990bb2515">

## Solution

Don't add an empty string

<img width="256" alt="Bildschirmfoto 2024-11-08 um 12 46 54" src="https://github.com/user-attachments/assets/68d1374d-a10d-4c38-8ee4-036bf22e27fd">
