### PR TITLE
Add script to update `Tooltip` imports from `@mui/material` to `@comet/admin`

### DIFF
--- a/src/v8/update-import-of-tooltip.ts
+++ b/src/v8/update-import-of-tooltip.ts
@@ -1,4 +1,3 @@
-import { readFile, writeFile } from "fs/promises";
 import { glob } from "glob";
 import { Project } from "ts-morph";
 
@@ -47,9 +46,5 @@ export default async function updateImportOfTooltip() {
         }
 
         await sourceFile.save();
-
-        const fileContent = (await readFile(filePath)).toString();
-
-        await writeFile(filePath, fileContent);
     }
 }

--- a/src/v8/update-import-of-tooltip.ts
+++ b/src/v8/update-import-of-tooltip.ts
@@ -22,19 +22,19 @@ export default async function updateImportOfTooltip() {
             }
         }
 
-        const muiTooltipImport = sourceFile.getImportDeclaration((declaration) => declaration.getModuleSpecifierValue() === "@mui/material");
+        const muiImport = sourceFile.getImportDeclaration((declaration) => declaration.getModuleSpecifierValue() === "@mui/material");
 
-        if (!muiTooltipImport) continue;
+        if (!muiImport) continue;
 
-        const namedImports = muiTooltipImport.getNamedImports();
+        const namedImports = muiImport.getNamedImports();
         const tooltipImport = namedImports.find((namedImport) => namedImport.getText() === "Tooltip");
 
         if (tooltipImport) {
             tooltipImport.remove();
         }
 
-        if (muiTooltipImport.getNamedImports().length === 0) {
-            muiTooltipImport.remove();
+        if (muiImport.getNamedImports().length === 0) {
+            muiImport.remove();
         }
 
         if (adminImport) {

--- a/src/v8/update-import-of-tooltip.ts
+++ b/src/v8/update-import-of-tooltip.ts
@@ -1,0 +1,55 @@
+import { readFile, writeFile } from "fs/promises";
+import { glob } from "glob";
+import { Project } from "ts-morph";
+
+export default async function updateImportOfTooltip() {
+    const project = new Project({ tsConfigFilePath: "./admin/tsconfig.json" });
+    const files: string[] = glob.sync(["admin/src/**/*.tsx"]);
+
+    for (const filePath of files) {
+        const sourceFile = project.getSourceFile(filePath);
+
+        if (!sourceFile) {
+            throw new Error(`Can't get source file for ${filePath}`);
+        }
+
+        const adminImport = sourceFile.getImportDeclaration((declaration) => declaration.getModuleSpecifierValue().includes("@comet/admin"));
+        const adminImports = adminImport?.getNamedImports().map((namedImport) => namedImport.getText());
+
+        if (adminImports) {
+            if (adminImports.includes("Tooltip")) {
+                continue;
+            }
+        }
+
+        const muiTooltipImport = sourceFile.getImportDeclaration((declaration) => declaration.getModuleSpecifierValue() === "@mui/material");
+
+        if (!muiTooltipImport) continue;
+
+        const namedImports = muiTooltipImport.getNamedImports();
+        const tooltipImport = namedImports.find((namedImport) => namedImport.getText() === "Tooltip");
+
+        if (tooltipImport) {
+            tooltipImport.remove();
+        }
+
+        if (muiTooltipImport.getNamedImports().length === 0) {
+            muiTooltipImport.remove();
+        }
+
+        if (adminImport) {
+            adminImport.addNamedImports(["Tooltip"]);
+        } else {
+            sourceFile.addImportDeclaration({
+                namedImports: ["Tooltip"],
+                moduleSpecifier: "@comet/admin",
+            });
+        }
+
+        await sourceFile.save();
+
+        const fileContent = (await readFile(filePath)).toString();
+
+        await writeFile(filePath, fileContent);
+    }
+}


### PR DESCRIPTION
### Definition

Add script to update Tooltip imports from @mui/material to @comet/admin


### Screenshots

For testing the script, I created some Test components in a random Comet 7 project:

1. Update Import from Mui:

<img width="1250" alt="Screenshot 2024-12-11 at 16 37 16" src="https://github.com/user-attachments/assets/d9fbc414-ca5a-4e83-913e-c462b2d57d81" />


2. Update Import from Admin - nothing should happen:

<img width="513" alt="Screenshot 2024-12-11 at 16 37 04" src="https://github.com/user-attachments/assets/ac081414-3ddc-4dfa-848a-f7977a6f8d52" />


3. Update Import from Mui, if multiple Files are imported from Mui:

<img width="1256" alt="Screenshot 2024-12-11 at 16 37 10" src="https://github.com/user-attachments/assets/bb574226-14e0-45bc-b8b8-e027840e5a26" />


4. Update Import from Mui, if another File from Admin is imported:

<img width="1253" alt="Screenshot 2024-12-11 at 16 37 24" src="https://github.com/user-attachments/assets/2791edc5-5542-4feb-b58f-fbea2d284d09" />

