### PR TITLE
Add script for renaming menu components

### DIFF
--- a/src/v8/rename-menu-components-in-admin.ts
+++ b/src/v8/rename-menu-components-in-admin.ts
@@ -1,0 +1,62 @@
+import { glob } from "glob";
+import { Project, ts } from "ts-morph";
+
+const renameMap: Record<string, string> = {
+    IMenuContent: "IMainNavigation",
+    IWithMenu: "IWithMainNavigation",
+    Menu: "MainNavigation",
+    MenuClassKey: "MainNavigationClassKey",
+    MenuCollapsibleItem: "MainNavigationCollapsibleItem",
+    MenuCollapsibleItemClassKey: "MainNavigationCollapsibleItemClassKey",
+    MenuCollapsibleItemProps: "MainNavigationCollapsibleItemProps",
+    MenuContext: "MainNavigationContext",
+    MenuItem: "MainNavigationItem",
+    MenuItemAnchorLink: "MainNavigationItemAnchorLink",
+    MenuItemAnchorLinkProps: "MainNavigationItemAnchorLinkProps",
+    MenuItemClassKey: "MainNavigationItemClassKey",
+    MenuItemGroup: "MainNavigationItemGroup",
+    MenuItemGroupClassKey: "MainNavigationItemGroupClassKey",
+    MenuItemGroupProps: "MainNavigationItemGroupProps",
+    MenuItemProps: "MainNavigationItemProps",
+    MenuItemRouterLink: "MainNavigationItemRouterLink",
+    MenuItemRouterLinkProps: "MainNavigationItemRouterLinkProps",
+    MenuProps: "MainNavigationProps",
+    withMenu: "withMainNavigation",
+};
+
+export default async function renameComponents() {
+    const project = new Project({ tsConfigFilePath: "./admin/tsconfig.json" });
+    const files: string[] = glob.sync(["admin/src/**/*.tsx"]);
+
+    for (const filePath of files) {
+        const sourceFile = project.getSourceFile(filePath);
+
+        if (!sourceFile) {
+            throw new Error(`Can't get source file for ${filePath}`);
+        }
+
+        const adminImport = sourceFile.getImportDeclaration((declaration) => declaration.getModuleSpecifierValue() === "@comet/admin");
+
+        if (adminImport) {
+            const namedImports = adminImport.getNamedImports();
+
+            for (const [oldName, newName] of Object.entries(renameMap)) {
+                const namedImport = namedImports.find((imported) => imported.getName() === oldName);
+
+                if (namedImport) {
+                    namedImport.setName(newName);
+
+                    const references = sourceFile
+                        .getDescendantsOfKind(ts.SyntaxKind.Identifier)
+                        .filter((identifier) => identifier.getText() === oldName);
+
+                    for (const reference of references) {
+                        reference.replaceWithText(newName);
+                    }
+                }
+            }
+        }
+
+        await sourceFile.save();
+    }
+}

--- a/src/v8/rename-menu-components-in-admin.ts
+++ b/src/v8/rename-menu-components-in-admin.ts
@@ -2,26 +2,25 @@ import { glob } from "glob";
 import { Project, ts } from "ts-morph";
 
 const renameMap: Record<string, string> = {
-    IMenuContent: "MainNavigationContextValue",
-    IWithMenu: "WithMainNavigation",
     Menu: "MainNavigation",
+    MenuProps: "MainNavigationProps",
     MenuClassKey: "MainNavigationClassKey",
-    MenuCollapsibleItem: "MainNavigationCollapsibleItem",
-    MenuCollapsibleItemClassKey: "MainNavigationCollapsibleItemClassKey",
-    MenuCollapsibleItemProps: "MainNavigationCollapsibleItemProps",
-    MenuContext: "useMainNavigation",
     MenuItem: "MainNavigationItem",
+    MenuItemProps: "MainNavigationItemProps",
+    MenuItemClassKey: "MainNavigationItemClassKey",
+    MenuCollapsibleItem: "MainNavigationCollapsibleItem",
+    MenuCollapsibleItemProps: "MainNavigationCollapsibleItemProps",
+    MenuCollapsibleItemClassKey: "MainNavigationCollapsibleItemClassKey",
+    IWithMenu: "WithMainNavigation",
+    withMenu: "withMainNavigation",
     MenuItemAnchorLink: "MainNavigationItemAnchorLink",
     MenuItemAnchorLinkProps: "MainNavigationItemAnchorLinkProps",
-    MenuItemClassKey: "MainNavigationItemClassKey",
     MenuItemGroup: "MainNavigationItemGroup",
     MenuItemGroupClassKey: "MainNavigationItemGroupClassKey",
     MenuItemGroupProps: "MainNavigationItemGroupProps",
-    MenuItemProps: "MainNavigationItemProps",
     MenuItemRouterLink: "MainNavigationItemRouterLink",
     MenuItemRouterLinkProps: "MainNavigationItemRouterLinkProps",
-    MenuProps: "MainNavigationProps",
-    withMenu: "withMainNavigation",
+    MenuContext: "useMainNavigation",
 };
 
 export default async function renameComponents() {

--- a/src/v8/rename-menu-components-in-admin.ts
+++ b/src/v8/rename-menu-components-in-admin.ts
@@ -2,8 +2,8 @@ import { glob } from "glob";
 import { Project, ts } from "ts-morph";
 
 const renameMap: Record<string, string> = {
-    IMenuContent: "IMainNavigation",
-    IWithMenu: "IWithMainNavigation",
+    IMenuContent: "MainNavigationContextValue",
+    IWithMenu: "WithMainNavigation",
     Menu: "MainNavigation",
     MenuClassKey: "MainNavigationClassKey",
     MenuCollapsibleItem: "MainNavigationCollapsibleItem",

--- a/src/v8/rename-menu-components-in-admin.ts
+++ b/src/v8/rename-menu-components-in-admin.ts
@@ -9,7 +9,7 @@ const renameMap: Record<string, string> = {
     MenuCollapsibleItem: "MainNavigationCollapsibleItem",
     MenuCollapsibleItemClassKey: "MainNavigationCollapsibleItemClassKey",
     MenuCollapsibleItemProps: "MainNavigationCollapsibleItemProps",
-    MenuContext: "MainNavigationContext",
+    MenuContext: "useMainNavigation",
     MenuItem: "MainNavigationItem",
     MenuItemAnchorLink: "MainNavigationItemAnchorLink",
     MenuItemAnchorLinkProps: "MainNavigationItemAnchorLinkProps",
@@ -46,12 +46,27 @@ export default async function renameComponents() {
                 if (namedImport) {
                     namedImport.setName(newName);
 
-                    const references = sourceFile
-                        .getDescendantsOfKind(ts.SyntaxKind.Identifier)
-                        .filter((identifier) => identifier.getText() === oldName);
+                    if (oldName === "MenuContext") {
+                        const useContextCalls = sourceFile.getDescendantsOfKind(ts.SyntaxKind.CallExpression).filter((call) => {
+                            const expression = call.getExpression();
+                            return (
+                                expression.getText() === "useContext" &&
+                                call.getArguments().length === 1 &&
+                                call.getArguments()[0].getText() === "MenuContext"
+                            );
+                        });
 
-                    for (const reference of references) {
-                        reference.replaceWithText(newName);
+                        for (const call of useContextCalls) {
+                            call.replaceWithText("useMainNavigation()");
+                        }
+                    } else {
+                        const references = sourceFile
+                            .getDescendantsOfKind(ts.SyntaxKind.Identifier)
+                            .filter((identifier) => identifier.getText() === oldName);
+
+                        for (const reference of references) {
+                            reference.replaceWithText(newName);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Update naming of admin components:

- Menu → MainNavigation
- MenuItem → MainNavigationItem
- MenuCollapsibleItem → MainNavigationCollapsibleItem
- MenuContext → MainNavigationContext
- MenuItemAnchorLink → MainNavigationAnchorLinkItem
- MenuItemGroup → MainNavigationItemGroup
- MenuItemRouterLink → MainNavigationRouterLinkItem


## Example update

Tested in a random comet 7 project:

- Components imported from @comet/admin will be updated.
- Components imported from @mui-material stay as they are:

<img width="1170" alt="Screenshot 2024-12-30 at 10 49 46" src="https://github.com/user-attachments/assets/2589be3d-c1d4-4486-a132-efad73f5dec5" />


https://github.com/vivid-planet/comet/pull/2996

https://vivid-planet.atlassian.net/browse/COM-1480
