### PR TITLE
Upgrade to latest version if called with shorthand like 'v7'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import path from "path";
 import semver, { SemVer } from "semver";
 
 import { executeCommand } from "./util/execute-command.util";
+import { getLatestPackageVersion } from "./util/get-latest-package-version";
 
 const microservices = ["api", "admin", "site"] as const;
 
@@ -11,7 +12,7 @@ function microserviceExists(microservice: "api" | "admin" | "site") {
 }
 
 async function main() {
-    const targetVersionArg = process.argv[2];
+    let targetVersionArg = process.argv[2];
 
     if (targetVersionArg === undefined) {
         console.error("Missing target version! Usage: npx @comet/upgrade <version>");
@@ -38,6 +39,9 @@ async function main() {
         return;
     }
 
+    if (!targetVersionArg.includes(".")) {
+        targetVersionArg = (await getLatestPackageVersion("@comet/admin")) ?? targetVersionArg;
+    }
     const targetVersion = semver.coerce(targetVersionArg, { includePrerelease: true });
 
     if (!targetVersion) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ async function main() {
     }
 
     if (!targetVersionArg.includes(".")) {
-        targetVersionArg = (await getLatestPackageVersion("@comet/admin")) ?? targetVersionArg;
+        targetVersionArg = (await getLatestPackageVersion("@comet/admin", semver.coerce(targetVersionArg)?.major)) ?? targetVersionArg;
     }
     const targetVersion = semver.coerce(targetVersionArg, { includePrerelease: true });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ async function main() {
     }
 
     if (!targetVersionArg.includes(".")) {
-        targetVersionArg = (await getLatestPackageVersion("@comet/admin", semver.coerce(targetVersionArg)?.major)) ?? targetVersionArg;
+        targetVersionArg = await getLatestPackageVersion("@comet/admin", semver.coerce(targetVersionArg)?.major);
     }
     const targetVersion = semver.coerce(targetVersionArg, { includePrerelease: true });
 

--- a/src/util/get-latest-package-version.ts
+++ b/src/util/get-latest-package-version.ts
@@ -1,5 +1,7 @@
-export async function getLatestPackageVersion(packageName: string) {
-    const url = `https://registry.npmjs.org/${packageName}/latest`;
+import semver from "semver";
+
+export async function getLatestPackageVersion(packageName: string, majorVersion?: number): Promise<string | null> {
+    const url = `https://registry.npmjs.org/${packageName}`;
 
     try {
         const response = await fetch(url);
@@ -7,8 +9,16 @@ export async function getLatestPackageVersion(packageName: string) {
             throw new Error(`Failed to fetch package info: ${response.status} ${response.statusText}`);
         }
 
-        const packageInfo = await response.json();
-        return (packageInfo as { version: string }).version;
+        const packageInfo = (await response.json()) as { version: string; versions: { [version: string]: unknown } };
+
+        if (!majorVersion) {
+            return packageInfo.version;
+        }
+
+        const versions: string[] = Object.keys(packageInfo.versions);
+        const latestForMajor = versions.filter((version) => semver.satisfies(version, `^${majorVersion}.0.0`)).sort(semver.rcompare)[0];
+
+        return latestForMajor || null;
     } catch (error) {
         console.error(`Failed to fetch package info for ${packageName}: ${error}`);
         return null;

--- a/src/util/get-latest-package-version.ts
+++ b/src/util/get-latest-package-version.ts
@@ -20,7 +20,6 @@ export async function getLatestPackageVersion(packageName: string, majorVersion?
 
         return latestForMajor || null;
     } catch (error) {
-        console.error(`Failed to fetch package info for ${packageName}: ${error}`);
-        return null;
+        throw new Error(`Failed to fetch package info for ${packageName}: ${error}`);
     }
 }

--- a/src/util/get-latest-package-version.ts
+++ b/src/util/get-latest-package-version.ts
@@ -1,0 +1,16 @@
+export async function getLatestPackageVersion(packageName: string) {
+    const url = `https://registry.npmjs.org/${packageName}/latest`;
+
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`Failed to fetch package info: ${response.status} ${response.statusText}`);
+        }
+
+        const packageInfo = await response.json();
+        return (packageInfo as { version: string }).version;
+    } catch (error) {
+        console.error(`Failed to fetch package info for ${packageName}: ${error}`);
+        return null;
+    }
+}

--- a/src/util/get-latest-package-version.ts
+++ b/src/util/get-latest-package-version.ts
@@ -1,6 +1,6 @@
 import semver from "semver";
 
-export async function getLatestPackageVersion(packageName: string, majorVersion?: number): Promise<string | null> {
+export async function getLatestPackageVersion(packageName: string, majorVersion?: number): Promise<string> {
     const url = `https://registry.npmjs.org/${packageName}`;
 
     try {
@@ -18,7 +18,7 @@ export async function getLatestPackageVersion(packageName: string, majorVersion?
         const versions: string[] = Object.keys(packageInfo.versions);
         const latestForMajor = versions.filter((version) => semver.satisfies(version, `^${majorVersion}.0.0`)).sort(semver.rcompare)[0];
 
-        return latestForMajor || null;
+        return latestForMajor;
     } catch (error) {
         throw new Error(`Failed to fetch package info for ${packageName}: ${error}`);
     }


### PR DESCRIPTION
Alternative to https://github.com/vivid-planet/comet-upgrade/pull/47

## Problem

When using a shorthand for the version (e.g., `npx @comet/upgrade@latest v7`), v7.0.0 is installed instead of the newest available verion v7.12.0. 

## Solution

If a version shorthand is entered, the latest COMET version is fetched from npm and used.

### Potential downsides (compared to #47)

We now depend on the npm API. However, we already depend on npm since the next step is executing an npm install. So if npm is down, neither the install nor getting the latest version will work.

## Note

Knowing the exact target version is also a prerequisite to https://github.com/vivid-planet/comet-upgrade/pull/52

https://vivid-planet.atlassian.net/browse/COM-1483