### PR TITLE
RFC: Allow scripts to specify a version to only execute them once

### DIFF
--- a/src/util/get-installed-package-version.ts
+++ b/src/util/get-installed-package-version.ts
@@ -1,9 +1,6 @@
 import path from "path";
-import semver, { SemVer } from "semver";
 
-import { microservices } from "../index";
-
-function getInstalledPackageVersion(packageName: string, microservice?: string): string | null {
+export function getInstalledPackageVersion(packageName: string, microservice?: string): string | null {
     try {
         const packageJsonPath = path.join(`${process.cwd()}${microservice ? `/${microservice}` : ""}`, "node_modules", packageName, "package.json");
         // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -12,30 +9,4 @@ function getInstalledPackageVersion(packageName: string, microservice?: string):
     } catch (error) {
         return null;
     }
-}
-
-export function getSmallestInstalledVersion(packages: Record<(typeof microservices)[number], string[]>, devDepdencies: string[]) {
-    const rootVersions = devDepdencies.map((packageName) => {
-        return getInstalledPackageVersion(packageName);
-    });
-
-    const microServiceVersions = microservices
-        .map((microservice) => {
-            const devDependencyVersions = devDepdencies.map((packageName) => {
-                return getInstalledPackageVersion(packageName, microservice);
-            });
-
-            const dependencyVersions = packages[microservice].map((packageName) => {
-                return getInstalledPackageVersion(packageName, microservice);
-            });
-
-            return [...devDependencyVersions, ...dependencyVersions];
-        })
-        .flat();
-
-    const allVersions = [...rootVersions, ...microServiceVersions].filter((version) => version !== null) as string[];
-
-    const sortedVersions = allVersions.map((version) => semver.coerce(version) as SemVer).sort(semver.rcompare);
-
-    return sortedVersions[0].version;
 }

--- a/src/util/get-installed-package-version.ts
+++ b/src/util/get-installed-package-version.ts
@@ -1,0 +1,41 @@
+import path from "path";
+import semver, { SemVer } from "semver";
+
+import { microservices } from "../index";
+
+function getInstalledPackageVersion(packageName: string, microservice?: string): string | null {
+    try {
+        const packageJsonPath = path.join(`${process.cwd()}${microservice ? `/${microservice}` : ""}`, "node_modules", packageName, "package.json");
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const packageJson = require(packageJsonPath);
+        return packageJson.version;
+    } catch (error) {
+        return null;
+    }
+}
+
+export function getSmallestInstalledVersion(packages: Record<(typeof microservices)[number], string[]>, devDepdencies: string[]) {
+    const rootVersions = devDepdencies.map((packageName) => {
+        return getInstalledPackageVersion(packageName);
+    });
+
+    const microServiceVersions = microservices
+        .map((microservice) => {
+            const devDependencyVersions = devDepdencies.map((packageName) => {
+                return getInstalledPackageVersion(packageName, microservice);
+            });
+
+            const dependencyVersions = packages[microservice].map((packageName) => {
+                return getInstalledPackageVersion(packageName, microservice);
+            });
+
+            return [...devDependencyVersions, ...dependencyVersions];
+        })
+        .flat();
+
+    const allVersions = [...rootVersions, ...microServiceVersions].filter((version) => version !== null) as string[];
+
+    const sortedVersions = allVersions.map((version) => semver.coerce(version) as SemVer).sort(semver.rcompare);
+
+    return sortedVersions[0].version;
+}

--- a/src/v7/add-site-preview-secret.ts
+++ b/src/v7/add-site-preview-secret.ts
@@ -4,6 +4,8 @@ import { Project, SyntaxKind } from "ts-morph";
 
 import { executeCommand } from "../util/execute-command.util";
 
+export const version = "7.6.0";
+
 export default async function addSitePreviewSecret() {
     updateApiFiles1();
     updateApiFiles2();

--- a/src/v7/hide-graphql-field-suggestions.ts
+++ b/src/v7/hide-graphql-field-suggestions.ts
@@ -1,5 +1,7 @@
 import { Project, SyntaxKind } from "ts-morph";
 
+export const version = "7.0.0";
+
 /**
  * Adds the `formatError` property to `GraphQLModule` options to hide `GraphQL` field suggestions for non dev environments.
  */

--- a/src/v7/import-admin-theme-types.ts
+++ b/src/v7/import-admin-theme-types.ts
@@ -3,6 +3,8 @@ import { readFile, writeFile } from "fs/promises";
 
 import { formatCode } from "../util/format-code.util";
 
+export const version = "7.0.0";
+
 /**
  * Imports types from `@comet/admin-theme` in vendors.d.ts to allow using custom theme variants and colors
  */

--- a/src/v7/rename-date-filter-to-date-time-filter.ts
+++ b/src/v7/rename-date-filter-to-date-time-filter.ts
@@ -3,6 +3,8 @@ import { glob } from "glob";
 
 import { formatCode } from "../util/format-code.util";
 
+export const version = "7.0.0";
+
 // Renames DateFilter to DateTimeFilter
 export default async function renameDateFilterToDateTimeFilter() {
     const files: string[] = glob.sync(["api/src/**/*.ts"]);

--- a/src/v7/replace-exception-interceptor-with-exception-filter.ts
+++ b/src/v7/replace-exception-interceptor-with-exception-filter.ts
@@ -2,6 +2,8 @@ import { readFile, writeFile } from "fs/promises";
 
 import { formatCode } from "../util/format-code.util";
 
+export const version = "7.12.0";
+
 /**
  * Replaces the old ExceptionInterceptor with the new ExceptionFilter
  */

--- a/src/v7/replace-gridcoldef-import.ts
+++ b/src/v7/replace-gridcoldef-import.ts
@@ -2,6 +2,8 @@ import { readFile } from "fs/promises";
 import { glob } from "glob";
 import { Project } from "ts-morph";
 
+export const version = "7.0.0";
+
 /**
  * Replaces the import of `GridColDef` from `@mui/x-data-grid*` with `GridColDef` from `@comet/admin`.
  */

--- a/src/v7/replace-roboto-with-roboto-flex.ts
+++ b/src/v7/replace-roboto-with-roboto-flex.ts
@@ -3,6 +3,8 @@ import { readFile, writeFile } from "fs/promises";
 import { executeCommand } from "../util/execute-command.util";
 import { formatCode } from "../util/format-code.util";
 
+export const version = "7.0.0";
+
 /**
  * Replaces the old font package "Roboto" with the new "Roboto Flex"
  */

--- a/src/v7/use-graphql-scalars.ts
+++ b/src/v7/use-graphql-scalars.ts
@@ -4,6 +4,8 @@ import { glob } from "glob";
 import { executeCommand } from "../util/execute-command.util";
 import { formatCode } from "../util/format-code.util";
 
+export const version = "7.0.0";
+
 export default async function useGraphqlScalars() {
     // replace graphql-type-json with graphql-scalars in api/package.json
     const packageJson = await readFile(`api/package.json`);

--- a/src/v8/merge-blocks-api-into-cms-api.ts
+++ b/src/v8/merge-blocks-api-into-cms-api.ts
@@ -2,6 +2,8 @@ import { readFile, writeFile } from "fs/promises";
 import { glob } from "glob";
 import { Project } from "ts-morph";
 
+export const version = "8.0.0";
+
 const renamedExports = {
     getMostSignificantPreviewImageUrlTemplate: "getMostSignificantPreviewImageUrlTemplateFromBlock",
     getPreviewImageUrlTemplates: "getPreviewImageUrlTemplatesFromBlock",

--- a/src/v8/mikro-orm-base-entity-generic.ts
+++ b/src/v8/mikro-orm-base-entity-generic.ts
@@ -1,6 +1,8 @@
 import { readFile, writeFile } from "fs/promises";
 import { glob } from "glob";
 
+export const version = "8.0.0";
+
 /**
  * BaseEntity no longer has generic type arguments.
  * See https://mikro-orm.io/docs/upgrading-v5-to-v6#baseentity-no-longer-has-generic-type-arguments.

--- a/src/v8/mikro-orm-custom-type.ts
+++ b/src/v8/mikro-orm-custom-type.ts
@@ -1,6 +1,8 @@
 import { readFile, writeFile } from "fs/promises";
 import { glob } from "glob";
 
+export const version = "8.0.0";
+
 /**
  * Custom type has been removed in favor of just type.
  * See https://mikro-orm.io/docs/upgrading-v5-to-v6#removed-propertyoptionscustomtype-in-favour-of-just-type.

--- a/src/v8/mikro-orm-delete-rule.ts
+++ b/src/v8/mikro-orm-delete-rule.ts
@@ -1,6 +1,8 @@
 import { readFile, writeFile } from "fs/promises";
 import { glob } from "glob";
 
+export const version = "8.0.0";
+
 /**
  * onDelete has been renamed to deleteRule.
  * See https://mikro-orm.io/docs/upgrading-v5-to-v6#renames.

--- a/src/v8/mikro-orm-dotenv.ts
+++ b/src/v8/mikro-orm-dotenv.ts
@@ -2,6 +2,8 @@ import { existsSync } from "fs";
 
 import { PackageJson } from "../util/package-json.util";
 
+export const version = "8.0.0";
+
 /**
  * Adds a `mikro-orm` script to package.json that calls dotenv.
  * See https://mikro-orm.io/docs/upgrading-v5-to-v6#env-files-are-no-longer-automatically-loaded.

--- a/src/v8/mikro-orm-imports.ts
+++ b/src/v8/mikro-orm-imports.ts
@@ -1,6 +1,8 @@
 import { readFile, writeFile } from "fs/promises";
 import { glob } from "glob";
 
+export const version = "8.0.0";
+
 /**
  * Always import form `@mikro-orm/postgresql`.
  * See https://mikro-orm.io/docs/upgrading-v5-to-v6#all-drivers-now-re-export-the-mikro-ormcore-package.

--- a/src/v8/mikro-orm-ormconfig.ts
+++ b/src/v8/mikro-orm-ormconfig.ts
@@ -1,5 +1,7 @@
 import { Project, SyntaxKind } from "ts-morph";
 
+export const version = "8.0.0";
+
 /**
  * Wrap the config in createOrmConfig with defineConfig
  */

--- a/src/v8/mui-data-grid-remove-error-prop.ts
+++ b/src/v8/mui-data-grid-remove-error-prop.ts
@@ -1,5 +1,6 @@
 import { Project, SyntaxKind } from "ts-morph";
 
+export const version = "8.0.0";
 export default async function removeMuiDataGridErrorProp() {
     console.log("Remove error prop from DataGrid and DataGridPro components");
 

--- a/src/v8/mui-grid-sort-to-gql.ts
+++ b/src/v8/mui-grid-sort-to-gql.ts
@@ -1,6 +1,8 @@
 import { glob } from "glob";
 import { Project, SyntaxKind } from "ts-morph";
 
+export const version = "8.0.0";
+
 /**
  * This codemod changes `muiGridSortToGql` method from @comet/admin package.
  *

--- a/src/v8/mui-upgrade.ts
+++ b/src/v8/mui-upgrade.ts
@@ -3,6 +3,8 @@ import { existsSync } from "fs";
 import { executeCommand } from "../util/execute-command.util";
 import { updateDependencyVersion } from "../util/update-dependency-version.util";
 
+export const version = "8.0.0";
+
 const adminPackageJsonPath = "admin/package.json";
 
 export default async function updateMuiVersion() {

--- a/src/v8/nest-peer-dependencies.ts
+++ b/src/v8/nest-peer-dependencies.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 
 import { PackageJson } from "../util/package-json.util";
 
+export const version = "8.0.0";
 export const stage = "before-install";
 
 /**

--- a/src/v8/remove-blocks-packages.ts
+++ b/src/v8/remove-blocks-packages.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "fs";
 import { readFile, writeFile } from "fs/promises";
 
+export const version = "8.0.0";
 export const stage = "before-install";
 
 export default async function removeBlocksPackages() {

--- a/src/v8/remove-current-user-from-auth-module.ts
+++ b/src/v8/remove-current-user-from-auth-module.ts
@@ -1,5 +1,7 @@
 import { Project, SyntaxKind } from "ts-morph";
 
+export const version = "8.0.0";
+
 /**
  * from
  *

--- a/src/v8/remove-graphql-client-from-site-preview-handlers.ts
+++ b/src/v8/remove-graphql-client-from-site-preview-handlers.ts
@@ -1,6 +1,8 @@
 import { existsSync } from "fs";
 import { Project, SyntaxKind } from "ts-morph";
 
+export const version = "8.0.0";
+
 /**
  * Removes the GraphQL client/fetch from the site preview handlers
  *

--- a/src/v8/remove-passport.ts
+++ b/src/v8/remove-passport.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 
 import { PackageJson } from "../util/package-json.util";
 
+export const version = "8.0.0";
 export const stage = "before-install";
 
 export default async function removePassport() {

--- a/src/v8/update-class-validator.ts
+++ b/src/v8/update-class-validator.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "fs";
 import { readFile, writeFile } from "fs/promises";
 
+export const version = "8.0.0";
 export const stage = "before-install";
 
 export default async function updateClassValidator() {

--- a/src/v8/update-graphql-format-error.ts
+++ b/src/v8/update-graphql-format-error.ts
@@ -1,5 +1,7 @@
 import { Project, SyntaxKind } from "ts-morph";
 
+export const version = "8.0.0";
+
 /**
  * From
  *

--- a/src/v8/update-import-of-dialog.ts
+++ b/src/v8/update-import-of-dialog.ts
@@ -1,6 +1,7 @@
 import { glob } from "glob";
 import { Project } from "ts-morph";
 
+export const version = "8.0.0";
 export default async function updateImportOfDialog() {
     const project = new Project({ tsConfigFilePath: "./admin/tsconfig.json" });
     const files: string[] = glob.sync(["admin/src/**/*.tsx"]);

--- a/src/v8/update-import-of-tooltip.ts
+++ b/src/v8/update-import-of-tooltip.ts
@@ -1,6 +1,7 @@
 import { glob } from "glob";
 import { Project } from "ts-morph";
 
+export const version = "8.0.0";
 export default async function updateImportOfTooltip() {
     const project = new Project({ tsConfigFilePath: "./admin/tsconfig.json" });
     const files: string[] = glob.sync(["admin/src/**/*.tsx"]);

--- a/src/v8/update-mikro-orm-dependencies.ts
+++ b/src/v8/update-mikro-orm-dependencies.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 
 import { PackageJson } from "../util/package-json.util";
 
+export const version = "8.0.0";
 export const stage = "before-install";
 
 export default async function updateNestDependencies() {

--- a/src/v8/update-nest-dependencies.ts
+++ b/src/v8/update-nest-dependencies.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 
 import { PackageJson } from "../util/package-json.util";
 
+export const version = "8.0.0";
 export const stage = "before-install";
 
 export default async function updateNestDependencies() {


### PR DESCRIPTION
depends on #51 

## Problem

Currently, when updating to any v7 version all v7 upgrade scripts are executed (regardless of what my current and target version is). However, some upgrade scripts aren't meant to be executed twice (e.g., `add-site-preview-secret.ts`) -> executing it again breaks the code and I have to clean up manually

## Proposed solution

You can now set a version for an upgrade script by exporting a `version`. These scripts are only executed if the version is greater than the current version but less or equal to the target version.

Scripts without a version are executed every time and should be "resilient" to multi-execution (only have an effect once).

https://vivid-planet.atlassian.net/browse/COM-1483