### PR TITLE
Add upgrade script for removing Tooltip's trigger prop

### DIFF
--- a/src/v8/remove-trigger-prop-from-tooltip.ts
+++ b/src/v8/remove-trigger-prop-from-tooltip.ts
@@ -1,0 +1,37 @@
+import { Project, SyntaxKind } from "ts-morph";
+
+export default async function removeTooltipTriggerProp() {
+    const project = new Project({ tsConfigFilePath: "./admin/tsconfig.json" });
+
+    const sourceFiles = project.getSourceFiles("admin/src/**/*.tsx");
+
+    sourceFiles.forEach((sourceFile) => {
+        const importDeclarations = sourceFile.getImportDeclarations();
+        const tooltipImports = importDeclarations.filter((importDeclaration) => {
+            const moduleSpecifier = importDeclaration.getModuleSpecifier().getLiteralValue();
+            return moduleSpecifier === "@comet/admin";
+        });
+
+        if (tooltipImports.length > 0) {
+            const jsxElements = sourceFile.getDescendantsOfKind(SyntaxKind.JsxOpeningElement);
+
+            jsxElements.forEach((jsxElement) => {
+                const tagName = jsxElement.getTagNameNode().getText();
+                if (tagName.includes("Tooltip")) {
+                    const triggerProp = jsxElement
+                        .getAttributes()
+                        .find(
+                            (attribute) =>
+                                attribute.getKind() === SyntaxKind.JsxAttribute &&
+                                attribute.asKind(SyntaxKind.JsxAttribute)?.getNameNode().getText() === "trigger",
+                        );
+
+                    if (triggerProp) {
+                        triggerProp.remove();
+                    }
+                }
+            });
+            sourceFile.save();
+        }
+    });
+}


### PR DESCRIPTION
Removes `trigger` prop from `Tooltip`

(See https://github.com/vivid-planet/comet/pull/3103)

![Screenshot 2025-01-24 at 08 53 32](https://github.com/user-attachments/assets/e02137f2-e717-424f-8866-e8c9e92e3aca)
