### PR TITLE
Add script to add `DialogContent` in all existing `EditDialog`s

### DIFF
--- a/src/v8/add-dialog-content-to-edit-dialog.ts
+++ b/src/v8/add-dialog-content-to-edit-dialog.ts
@@ -1,0 +1,83 @@
+import { Node, Project, SyntaxKind, ts } from "ts-morph";
+
+export default async function addDialogContentToEditDialog() {
+    const project = new Project({ tsConfigFilePath: "./admin/tsconfig.json" });
+    const sourceFiles = project.getSourceFiles("admin/src/**/*.tsx");
+
+    sourceFiles.forEach((sourceFile) => {
+        const importDeclarations = sourceFile.getImportDeclarations();
+        const cometImport = importDeclarations.find(
+            (importDeclaration) => importDeclaration.getModuleSpecifier().getLiteralValue() === "@comet/admin",
+        );
+
+        let hasEditDialogImport = false;
+
+        if (cometImport) {
+            hasEditDialogImport = cometImport.getNamedImports().some((namedImport) => namedImport.getName() === "EditDialog");
+            if (hasEditDialogImport) {
+                cometImport.addNamedImport("DialogContent");
+            }
+        }
+
+        const jsxElements = sourceFile.getDescendantsOfKind(SyntaxKind.JsxElement);
+
+        const elementsToReplace: { node: Node<ts.Node>; newText: string }[] = [];
+
+        jsxElements.forEach((jsxElement) => {
+            const tagName = jsxElement.getOpeningElement().getTagNameNode().getText();
+            if (tagName !== "EditDialog") return;
+
+            const children = jsxElement.getJsxChildren();
+            const functionAsChild = children.find((child) => Node.isJsxExpression(child) && Node.isArrowFunction(child.getExpression()));
+
+            if (functionAsChild && Node.isJsxExpression(functionAsChild)) {
+                const expression = functionAsChild.getExpression();
+                if (!expression || !Node.isArrowFunction(expression)) return;
+
+                const body = expression.getBody();
+                const parameters = expression.getParameters();
+                let wrappedContent: string;
+
+                if (Node.isBlock(body)) {
+                    const returnStatement = body.getStatements().find((statement) => Node.isReturnStatement(statement));
+                    if (!returnStatement || !Node.isReturnStatement(returnStatement)) return;
+
+                    let returnedExpression = returnStatement.getExpression();
+                    if (returnedExpression && Node.isParenthesizedExpression(returnedExpression)) {
+                        returnedExpression = returnedExpression.getExpression();
+                    }
+
+                    if (!returnedExpression) return;
+
+                    if (Node.isJsxFragment(returnedExpression)) {
+                        const fragmentChildren = returnedExpression.getChildrenOfKind(SyntaxKind.JsxElement);
+                        const fragmentText = fragmentChildren.map((child) => child.getText()).join("\n");
+                        wrappedContent = `(<DialogContent>\n${fragmentText}\n</DialogContent>)`;
+                    } else {
+                        const innerContent = returnedExpression.getText().replace(/\n/g, "\n");
+                        wrappedContent = `(<DialogContent>\n${innerContent}\n</DialogContent>)`;
+                    }
+
+                    const newFunction = `{(${parameters.map((param) => param.getText()).join(", ")}) => {
+                        return ${wrappedContent};}}`;
+                    elementsToReplace.push({ node: functionAsChild, newText: newFunction });
+                }
+            } else {
+                const openEditDialog = jsxElement.getOpeningElement().getText();
+                const closeEditDialog = jsxElement.getClosingElement().getText();
+                const childrensContent = children.map((child) => child.getText()).join("\n");
+
+                const newContent = `${openEditDialog}\n<DialogContent>\n${childrensContent}\n</DialogContent>\n${closeEditDialog}`;
+                elementsToReplace.push({ node: jsxElement, newText: newContent });
+            }
+        });
+
+        elementsToReplace.forEach(({ node, newText }) => {
+            node.replaceWithText(newText);
+        });
+
+        sourceFile.saveSync();
+    });
+
+    await project.save();
+}

--- a/src/v8/add-dialog-content-to-edit-dialog.ts
+++ b/src/v8/add-dialog-content-to-edit-dialog.ts
@@ -6,17 +6,18 @@ export default async function addDialogContentToEditDialog() {
 
     sourceFiles.forEach((sourceFile) => {
         const importDeclarations = sourceFile.getImportDeclarations();
-        const cometImport = importDeclarations.find(
-            (importDeclaration) => importDeclaration.getModuleSpecifier().getLiteralValue() === "@comet/admin",
+
+        const muiImport = importDeclarations.find(
+            (importDeclaration) => importDeclaration.getModuleSpecifier().getLiteralValue() === "@mui/material",
         );
 
-        let hasEditDialogImport = false;
-
-        if (cometImport) {
-            hasEditDialogImport = cometImport.getNamedImports().some((namedImport) => namedImport.getName() === "EditDialog");
-            if (hasEditDialogImport) {
-                cometImport.addNamedImport("DialogContent");
-            }
+        if (!muiImport) {
+            sourceFile.addImportDeclaration({
+                moduleSpecifier: "@mui/material",
+                namedImports: ["DialogContent"],
+            });
+        } else if (!muiImport.getNamedImports().some((namedImport) => namedImport.getName() === "DialogContent")) {
+            muiImport.addNamedImport("DialogContent");
         }
 
         const jsxElements = sourceFile.getDescendantsOfKind(SyntaxKind.JsxElement);


### PR DESCRIPTION
This adds an update script for the changes in https://github.com/vivid-planet/comet/pull/3401

DialogContent was hardcoded to EditDialog before, but was removed. It needs to be added again in all existing EditDialogs.

NOTE: I tried to cover all examples of usages of the EditDialog from the storybook. 

![Screenshot 2025-02-14 at 10 02 07](https://github.com/user-attachments/assets/e87c6912-12f5-43be-9f9a-6d16dfb63ea4)
![Screenshot 2025-02-14 at 10 02 22](https://github.com/user-attachments/assets/9e5adf5a-5339-4449-83f5-bf61eecdffd1)
![Screenshot 2025-02-14 at 10 02 36](https://github.com/user-attachments/assets/4457b501-03df-4431-a774-913de6410b3e)
![Screenshot 2025-02-14 at 10 03 00](https://github.com/user-attachments/assets/1622c41d-3bc8-4569-9117-e306444c02ad)
![Screenshot 2025-02-14 at 10 03 11](https://github.com/user-attachments/assets/68e8e1dc-c961-4453-a6a7-9fe441acfe3e)
