### PR TITLE
feat: add codemod to fix rimraf glob pattern in generators

### DIFF
--- a/src/v8/fix-rim-raf-generator-scripts.ts
+++ b/src/v8/fix-rim-raf-generator-scripts.ts
@@ -1,0 +1,31 @@
+import { existsSync } from "fs";
+
+import { PackageJson } from "../util/package-json.util";
+
+/**
+ * Fixes the rimraf command in the generator scripts in the package.json files.
+ *
+ * adding a `-g` glob pattern to the rimraf command and updating the glob pattern to match the generated folders
+ * will delete the generated folders again.
+ */
+export default async function fixRimRafGeneratorScripts() {
+    if (!existsSync("admin/package.json")) {
+        return;
+    }
+
+    const adminPackageJson = new PackageJson("admin/package.json");
+
+    adminPackageJson.addScript("admin-generator", "rimraf -g 'src/**/generated' && comet-admin-generator generate");
+
+    adminPackageJson.save();
+
+    if (!existsSync("admin/package.json")) {
+        return;
+    }
+
+    const apiPackageJson = new PackageJson("api/package.json");
+
+    apiPackageJson.addScript("api-generator", "rimraf 'src/*/generated' && comet-api-generator generate");
+
+    apiPackageJson.save();
+}


### PR DESCRIPTION
Adds a codmod that updates the scripts `admin-generator` in `admin/package.json` and `api-generator` in `api/package.json`, so that rimraf commando's work again, and the generated directories get deleted again when generator runs.


https://github.com/user-attachments/assets/94478af5-aae5-4577-bf9d-1581a5694d6f

