### PR TITLE
Highlight warn and error logs with chalk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.49.0",
             "license": "BSD-2-Clause",
             "dependencies": {
+                "chalk": "^4.1.2",
                 "eslint": "^8.56.0",
                 "glob": "^10.3.10",
                 "prettier": "^2.8.1",
@@ -1584,6 +1585,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -3284,6 +3286,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -6080,6 +6083,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "start": "npm run clean && tsc --watch"
     },
     "dependencies": {
+        "chalk": "^4.1.2",
         "eslint": "^8.56.0",
         "glob": "^10.3.10",
         "prettier": "^2.8.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import fs from "fs";
+import * as util from "node:util";
 import path from "path";
 import semver, { SemVer } from "semver";
 
@@ -229,11 +230,13 @@ const originalError = console.error;
 const originalWarn = console.warn;
 
 console.error = (...args) => {
-    originalError(chalk.red(...args));
+    const formattedArgs = args.map((arg) => (typeof arg === "object" ? util.inspect(arg, { depth: null, colors: true }) : chalk.red(arg)));
+    originalError(...formattedArgs);
 };
 
 console.warn = (...args) => {
-    originalWarn(chalk.yellow(...args));
+    const formattedArgs = args.map((arg) => (typeof arg === "object" ? util.inspect(arg, { depth: null, colors: true }) : chalk.yellow(arg)));
+    originalWarn(...formattedArgs);
 };
 
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import chalk from "chalk";
 import fs from "fs";
 import path from "path";
 import semver, { SemVer } from "semver";
@@ -223,5 +224,16 @@ function listTargetVersions() {
     const targetVersions = fs.readdirSync(__dirname).filter((entry) => entry.startsWith("v"));
     console.info(targetVersions.map((version) => `- ${version}`).join("\n"));
 }
+
+const originalError = console.error;
+const originalWarn = console.warn;
+
+console.error = (...args) => {
+    originalError(chalk.red(...args));
+};
+
+console.warn = (...args) => {
+    originalWarn(chalk.yellow(...args));
+};
 
 main();


### PR DESCRIPTION
`console.warn` is now highlighted in yellow and `console.error` is highlighted in red.

In my opinion, this increases readability and clarity and makes it less likely to overlook relevant information.

---

Before:

<img width="676" alt="Bildschirmfoto 2025-02-28 um 13 40 42" src="https://github.com/user-attachments/assets/fa353ce5-7672-41e9-87a2-16d571c3203f" />


Now:

<img width="747" alt="Bildschirmfoto 2025-02-28 um 13 39 55" src="https://github.com/user-attachments/assets/fd56c4cd-6308-48b0-9410-600c749296c5" />



