### PR TITLE
Always install an exact version of comet (without caret)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ async function updateDependencies(targetVersion: SemVer) {
             "--no-audit",
             "--loglevel",
             "error",
-            ...(targetVersion.prerelease.length > 0 ? ["--save-exact"] : []),
+            "--save-exact",
             ...dependencies.map((dependency) => `${dependency}@${targetVersion.version}`),
             ...devDependencies.map((dependency) => `${dependency}@${targetVersion.version}`),
         ]);


### PR DESCRIPTION
Otherwise, the version in package.json is always set with a ^, even if the previous version was already fixed.

---

Outcome:

```diff
- "@comet/admin": "^7.15.0",
+ "@comet/admin": "7.15.0",
```