### PR TITLE
Upgrade @comet/cli in root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,8 @@ function getCurrentVersion() {
 }
 
 async function updateDependencies(targetVersion: SemVer, isMajorUpdate = false) {
+    await executeCommand("npm", ["install", "--no-audit", "--loglevel", "error", "--save-exact", `@comet/cli@${targetVersion.version}`]);
+
     const packages: Record<(typeof microservices)[number], string[]> = {
         api: ["@comet/blocks-api", "@comet/cms-api"],
         admin: [


### PR DESCRIPTION
When using site configs, `@comet/cli` is needed in the project root to inject the site configs. Up until now, the upgrade scripts didn't update this dependency.

Now, `@comet/cli` in root is updated.