### PR TITLE
Remove `type` from ORM config

### DIFF
--- a/src/v8/mikro-orm-ormconfig.ts
+++ b/src/v8/mikro-orm-ormconfig.ts
@@ -23,6 +23,12 @@ export default async function replaceCustomType() {
         .getInitializerIfKindOrThrow(SyntaxKind.CallExpression)
         .getArguments()[0];
 
+    for (const propertyAssignment of config.getDescendantsOfKind(SyntaxKind.PropertyAssignment)) {
+        if (propertyAssignment.getName() === "type") {
+            propertyAssignment.remove();
+        }
+    }
+
     config.replaceWithText(`defineConfig(${config.getText()})`);
 
     await sourceFile.save();

--- a/src/v8/mikro-orm-ormconfig.ts
+++ b/src/v8/mikro-orm-ormconfig.ts
@@ -12,6 +12,10 @@ export default async function replaceCustomType() {
         return;
     }
 
+    if (sourceFile.getText().includes("defineConfig")) {
+        return;
+    }
+
     sourceFile.addImportDeclaration({
         namedImports: ["defineConfig"],
         moduleSpecifier: "@mikro-orm/postgresql",


### PR DESCRIPTION
- remove `type` property (because it doesn't exist anymore)
- make script idempotent