### PR TITLE
Don't run CI workflow on PR merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
             - opened
             - synchronize
             - reopened
-            - closed
         branches:
             - main
 


### PR DESCRIPTION
This causes duplicate runs since the workflow is also triggered for commits pushed to main.