### PR TITLE
Execute CI workflow on merge (again)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
             - opened
             - synchronize
             - reopened
+            - closed
         branches:
             - main
 


### PR DESCRIPTION
We removed this in https://github.com/vivid-planet/comet-upgrade/pull/83

The problem is the CI workflow publishes the package. Meaning, the package isn't published anymore:

<img width="1319" alt="Bildschirmfoto 2025-04-22 um 18 02 05" src="https://github.com/user-attachments/assets/128d4c02-f00d-45fd-8c46-e6467be2e015" />
