### PR TITLE
Add codemod for MUI date picker localization provider

### DIFF
--- a/src/v8/use-mui-date-picker-in-grid.ts
+++ b/src/v8/use-mui-date-picker-in-grid.ts
@@ -6,10 +6,14 @@ import { PackageJson } from "../util/package-json.util";
 export const stage = "before-install";
 
 /**
- * Prepares the admin to use the MUI DatePicker in a grid.
- *
- * This codmod adds the necessary dependencies for using the MUI DatePicker in a grid
- * and sets up the LocalizationProvider in App.tsx.
+ * Prepares the admin to use the MUI DatePicker in a grid by:
+ * 1. Installing dependencies:
+ *    - @mui/x-date-pickers
+ *    - date-fns
+ * 2. Setting up LocalizationProvider:
+ *    - Adds required imports
+ *    - Wraps app with LocalizationProvider (above MuiThemeProvider)
+ *    - Configures enUS locale with internationalization note
  */
 export default async function UseMuiDatePickerInGrid() {
     if (!existsSync("admin/package.json")) {


### PR DESCRIPTION
# Add MUI DatePicker Setup Codemod

This PR adds a new codemod (`use-mui-date-picker-in-grid.ts`) that prepares applications to use MUI's DatePicker component in data grids.


## Description

The codemod performs the following tasks:
1. Installs required dependencies:
   - `@mui/x-date-pickers@^7.29.4`
   - `date-fns@^4.1.0`

2. Sets up LocalizationProvider in `admin/src/App.tsx`:
   - Adds necessary imports for `LocalizationProvider` and `AdapterDateFns`
   - Imports `enUS` locale from `date-fns/locale`
   - Wraps the application (above `MuiThemeProvider`) with `LocalizationProvider`
   - Configures default locale to `enUS` with a TODO comment for internationalization- this must be manually applied from the developer if another language than `enUs` is used in the application

![Screen Recording 2025-07-04 at 09 02 09](https://github.com/user-attachments/assets/ec5f3241-0aa2-4ff1-b848-ae640753a1d4)

## Related for following changes:

- https://github.com/vivid-planet/comet/pull/3989
- https://github.com/vivid-planet/comet/pull/4109