### PR TITLE
Add upgrade scripts to remove React barrel imports

### DIFF
--- a/src/v8/remove-react-barrel-imports-admin.ts
+++ b/src/v8/remove-react-barrel-imports-admin.ts
@@ -25,9 +25,10 @@ export default async function removeReactBarrelImportsAdmin() {
             if (node.getKindName() === "PropertyAccessExpression") {
                 const text = node.getText();
                 if (text.startsWith("React.")) {
-                    const member = text.replace("React.", "");
-                    namedUsages.add(member);
-                    node.replaceWithText(member);
+                    // Only add the first property after React. as named import
+                    const member = text.split(".")[1];
+                    if (member) namedUsages.add(member);
+                    node.replaceWithText(text.replace("React.", ""));
                 }
             }
         });

--- a/src/v8/remove-react-barrel-imports-admin.ts
+++ b/src/v8/remove-react-barrel-imports-admin.ts
@@ -1,0 +1,44 @@
+import { glob } from "glob";
+import { Project } from "ts-morph";
+
+export default async function removeReactBarrelImportsAdmin() {
+    const project = new Project({ tsConfigFilePath: "./admin/tsconfig.json" });
+    const files: string[] = glob.sync(["admin/src/**/*.ts", "admin/src/**/*.tsx"]);
+
+    for (const filePath of files) {
+        const sourceFile = project.getSourceFile(filePath);
+        if (!sourceFile) continue;
+
+        // Find and remove all imports of React from "react"
+        const reactImports = sourceFile.getImportDeclarations().filter((imp) => imp.getModuleSpecifierValue() === "react");
+        const namedUsages = new Set<string>();
+        for (const imp of reactImports) {
+            // Collect named imports (if any)
+            const named = imp.getNamedImports().map((ni) => ni.getName());
+            named.forEach((n) => namedUsages.add(n));
+            // Remove the import
+            imp.remove();
+        }
+
+        // Find usages of React.something and replace with something
+        sourceFile.forEachDescendant((node) => {
+            if (node.getKindName() === "PropertyAccessExpression") {
+                const text = node.getText();
+                if (text.startsWith("React.")) {
+                    const member = text.replace("React.", "");
+                    namedUsages.add(member);
+                    node.replaceWithText(member);
+                }
+            }
+        });
+
+        // Add import { ... } from "react" for all used members
+        if (namedUsages.size > 0) {
+            sourceFile.addImportDeclaration({
+                namedImports: Array.from(namedUsages),
+                moduleSpecifier: "react",
+            });
+        }
+    }
+    await project.save();
+}

--- a/src/v8/remove-react-barrel-imports-site.ts
+++ b/src/v8/remove-react-barrel-imports-site.ts
@@ -1,0 +1,44 @@
+import { glob } from "glob";
+import { Project } from "ts-morph";
+
+export default async function removeReactBarrelImportsSite() {
+    const project = new Project({ tsConfigFilePath: "./site/tsconfig.json" });
+    const files: string[] = glob.sync(["site/src/**/*.ts", "site/src/**/*.tsx"]);
+
+    for (const filePath of files) {
+        const sourceFile = project.getSourceFile(filePath);
+        if (!sourceFile) continue;
+
+        // Find and remove all imports of React from "react"
+        const reactImports = sourceFile.getImportDeclarations().filter((imp) => imp.getModuleSpecifierValue() === "react");
+        const namedUsages = new Set<string>();
+        for (const imp of reactImports) {
+            // Collect named imports (if any)
+            const named = imp.getNamedImports().map((ni) => ni.getName());
+            named.forEach((n) => namedUsages.add(n));
+            // Remove the import
+            imp.remove();
+        }
+
+        // Find usages of React.something and replace with something
+        sourceFile.forEachDescendant((node) => {
+            if (node.getKindName() === "PropertyAccessExpression") {
+                const text = node.getText();
+                if (text.startsWith("React.")) {
+                    const member = text.replace("React.", "");
+                    namedUsages.add(member);
+                    node.replaceWithText(member);
+                }
+            }
+        });
+
+        // Add import { ... } from "react" for all used members
+        if (namedUsages.size > 0) {
+            sourceFile.addImportDeclaration({
+                namedImports: Array.from(namedUsages),
+                moduleSpecifier: "react",
+            });
+        }
+    }
+    await project.save();
+}

--- a/src/v8/remove-react-barrel-imports-site.ts
+++ b/src/v8/remove-react-barrel-imports-site.ts
@@ -25,9 +25,10 @@ export default async function removeReactBarrelImportsSite() {
             if (node.getKindName() === "PropertyAccessExpression") {
                 const text = node.getText();
                 if (text.startsWith("React.")) {
-                    const member = text.replace("React.", "");
-                    namedUsages.add(member);
-                    node.replaceWithText(member);
+                    // Only add the first property after React. as named import
+                    const member = text.split(".")[1];
+                    if (member) namedUsages.add(member);
+                    node.replaceWithText(text.replace("React.", ""));
                 }
             }
         });


### PR DESCRIPTION
There is an official codemod for this: `npx react-codemod update-react-imports --force`

But it doesn't work very good and for some reason leaves a lot of open issues. So I made another one.