### PR TITLE
Add `ignore-restricted-imports-admin` script

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ async function updateDependencies(targetVersion: SemVer, isMajorUpdate = false) 
 
 type UpgradeScript = {
     name: string;
-    stage: "before-install" | "after-install";
+    stage: "before-install" | "after-install" | "never";
     script: () => Promise<void>;
 };
 

--- a/src/v8/ignore-restricted-imports-admin.ts
+++ b/src/v8/ignore-restricted-imports-admin.ts
@@ -1,0 +1,29 @@
+import { Project } from "ts-morph";
+
+export const stage = "never";
+
+export default async function ignoreRestrictedImportsAdmin() {
+    const project = new Project({ tsConfigFilePath: "./admin/tsconfig.json" });
+    const sourceFiles = project.getSourceFiles("admin/src/**/*.tsx");
+
+    for (const sourceFile of sourceFiles) {
+        const imports = sourceFile.getImportDeclarations();
+        for (const imp of imports) {
+            const module = imp.getModuleSpecifierValue();
+            if (module === "@mui/material") {
+                const namedImports = imp.getNamedImports().map((ni) => ni.getName());
+                if (namedImports.includes("Button") || namedImports.includes("Dialog")) {
+                    // Check for existing comments above
+                    const statements = imp.getLeadingCommentRanges().map((r) => r.getText());
+                    const hasEslintComment = statements.some((s) => s.includes("eslint-disable-next-line no-restricted-imports"));
+                    if (!hasEslintComment) {
+                        imp.replaceWithText(
+                            `// TODO v8: remove eslint-disable-next-line\n// eslint-disable-next-line no-restricted-imports\n${imp.getText()}`,
+                        );
+                    }
+                }
+            }
+        }
+    }
+    await project.save();
+}

--- a/src/v8/remove-v8-eslint-disable-comments-admin.ts
+++ b/src/v8/remove-v8-eslint-disable-comments-admin.ts
@@ -1,0 +1,45 @@
+import { Project } from "ts-morph";
+
+export const stage = "never";
+
+export default async function ignoreRestrictedImportsAdmin() {
+    const project = new Project({ tsConfigFilePath: "./admin/tsconfig.json" });
+    const sourceFiles = project.getSourceFiles("admin/src/**/*.tsx");
+
+    for (const sourceFile of sourceFiles) {
+        const imports = sourceFile.getImportDeclarations();
+
+        // Store comments to remove as [start, end] tuples
+        const commentRangesToRemove: [number, number][] = [];
+
+        for (const imp of imports) {
+            const leadingComments = imp.getLeadingCommentRanges();
+
+            for (let i = 0; i < leadingComments.length - 1; i++) {
+                const first = leadingComments[i];
+                const second = leadingComments[i + 1];
+
+                const firstText = first.getText();
+                const secondText = second.getText();
+
+                if (
+                    firstText.includes("TODO v8: remove eslint-disable-next-line") &&
+                    secondText.includes("eslint-disable-next-line no-restricted-imports")
+                ) {
+                    // Mark both comments for removal
+                    commentRangesToRemove.push([second.getPos(), second.getEnd()]);
+                    commentRangesToRemove.push([first.getPos(), first.getEnd()]);
+                }
+            }
+        }
+
+        // Remove all comments from the file, in reverse order
+        commentRangesToRemove
+            .sort((a, b) => b[0] - a[0]) // Sort descending by start index
+            .forEach(([start, end]) => {
+                sourceFile.removeText(start, end);
+            });
+    }
+
+    await project.save();
+}

--- a/src/v8/remove-v8-eslint-disable-comments-admin.ts
+++ b/src/v8/remove-v8-eslint-disable-comments-admin.ts
@@ -2,7 +2,7 @@ import { Project } from "ts-morph";
 
 export const stage = "never";
 
-export default async function ignoreRestrictedImportsAdmin() {
+export default async function removeV8EslintDisableCommentsAdmin() {
     const project = new Project({ tsConfigFilePath: "./admin/tsconfig.json" });
     const sourceFiles = project.getSourceFiles("admin/src/**/*.tsx");
 


### PR DESCRIPTION
This adds a `ignore-restricted-imports-admin` that adds eslint-disable comments to import of Button and Dialog from `@mui/material`. It is never executed automatically.

I also added a script that removes the comments again in the after-install step.

### Why?

The exports of Button and Dialog from `@comet/admin` are only available in v8. But I want to decouple the eslint update from the v8 upgrade of the other packages. So this is meant as a temporary solution.