### PR TITLE
Fix: Only execute upgrade scripts twice locally

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,7 @@ function microserviceExists(microservice: "api" | "admin" | "site") {
     return fs.existsSync(`${microservice}/package.json`);
 }
 
-const isRunningViaNpx = Boolean(process.env.npm_execpath?.includes("npx"));
-const isLocalDevelopment = !isRunningViaNpx;
+const isLocalDevelopment = process.argv[0].endsWith("node");
 
 async function main() {
     let targetVersionArg = process.argv[2];
@@ -25,7 +24,7 @@ async function main() {
     }
 
     if (isLocalDevelopment) {
-        console.warn("Not running via npx -> assuming local development. Scripts will run twice to ensure idempotency.");
+        console.warn("Executed via node -> assuming local development. Scripts will run twice to ensure idempotency.");
     }
 
     const isUpgradeScript = targetVersionArg.endsWith(".ts");


### PR DESCRIPTION
The previous version doesn't work (anymore). This causes upgrade scripts to always being executed twice, even via npx.

argv looks like this for me:

```
[
  '/Users/thomasdax/.nvm/versions/node/v22.17.1/bin/node',
  '/Users/thomasdax/dev/vivid/comet-upgrade/bin/index.js',
  '8.0.0-beta.5'
]
```