### PR TITLE
Replace GraphQL playground with GraphiQL

### DIFF
--- a/src/v8/replace-playground-with-graphiql.ts
+++ b/src/v8/replace-playground-with-graphiql.ts
@@ -1,0 +1,68 @@
+import { Project, SyntaxKind } from "ts-morph";
+
+/**
+ * From
+ *
+ * GraphQLModule.forRootAsync<ApolloDriverConfig>({
+ *     useFactory: (moduleRef: ModuleRef) => ({
+ *         playground: config.debug,
+ *     }),
+ * }),
+ *
+ * to
+ *
+ * GraphQLModule.forRootAsync<ApolloDriverConfig>({
+ *     useFactory: (moduleRef: ModuleRef) => ({
+ *         graphiql: config.debug ? { url: "/api/graphql" } : undefined,
+ *         playground: false,
+ *     }),
+ * }),
+ */
+export default function () {
+    const project = new Project();
+    const filePath = "api/src/app.module.ts";
+    const sourceFile = project.addSourceFileAtPath(filePath);
+
+    for (const node of sourceFile.getDescendants()) {
+        if (node.getKind() === SyntaxKind.CallExpression && node.getText().startsWith("GraphQLModule.forRootAsync")) {
+            const callExpr = node.asKindOrThrow(SyntaxKind.CallExpression);
+            const arg = callExpr.getArguments()[0];
+            if (arg && arg.getKind() === SyntaxKind.ObjectLiteralExpression) {
+                const obj = arg.asKindOrThrow(SyntaxKind.ObjectLiteralExpression);
+                const useFactoryProp = obj.getProperty("useFactory");
+                if (useFactoryProp && useFactoryProp.getKind() === SyntaxKind.PropertyAssignment) {
+                    const useFactory = useFactoryProp.asKindOrThrow(SyntaxKind.PropertyAssignment);
+                    const arrowFunc = useFactory.getInitializerIfKind(SyntaxKind.ArrowFunction);
+                    if (arrowFunc) {
+                        const body = arrowFunc.getBody();
+                        if (body.getKind() === SyntaxKind.ParenthesizedExpression) {
+                            const retObj = body.getFirstChildByKind(SyntaxKind.ObjectLiteralExpression);
+                            if (retObj) {
+                                if (retObj.getProperty("graphiql")) {
+                                    return; // Already has graphiql property
+                                }
+
+                                // Replace playground: config.debug with playground: false
+                                const playgroundProp = retObj.getProperty("playground");
+
+                                if (playgroundProp) {
+                                    playgroundProp.replaceWithText("playground: false");
+                                }
+
+                                const graphiqlProperty = retObj.insertPropertyAssignment(playgroundProp ? playgroundProp.getChildIndex() - 1 : 0, {
+                                    name: "graphiql",
+                                    initializer: 'config.debug ? { url: "/api/graphql" } : undefined',
+                                });
+
+                                graphiqlProperty.replaceWithText(`// eslint-disable-next-line @cspell/spellchecker\n${graphiqlProperty.getText()}`);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    sourceFile.saveSync();
+}

--- a/src/v8/update-nest-dependencies.ts
+++ b/src/v8/update-nest-dependencies.ts
@@ -15,15 +15,15 @@ export default async function updateNestDependencies() {
     packageJson.removeDependency("apollo-server-core");
     packageJson.removeDependency("apollo-server-express");
 
-    packageJson.updateDependency("@nestjs/apollo", "^13.0.3");
-    packageJson.updateDependency("@nestjs/common", "^11.0.10");
-    packageJson.updateDependency("@nestjs/core", "^11.0.10");
-    packageJson.updateDependency("@nestjs/graphql", "^13.0.3");
+    packageJson.updateDependency("@nestjs/apollo", "^13.1.0");
+    packageJson.updateDependency("@nestjs/common", "^11.1.3");
+    packageJson.updateDependency("@nestjs/core", "^11.1.3");
+    packageJson.updateDependency("@nestjs/graphql", "^13.1.0");
     packageJson.updateDependency("@nestjs/mapped-types", "^2.1.0");
-    packageJson.updateDependency("@nestjs/platform-express", "^11.0.10");
-    packageJson.updateDependency("@nestjs/cli", "^11.0.3");
-    packageJson.updateDependency("@nestjs/schematics", "^11.0.1");
-    packageJson.updateDependency("@nestjs/testing", "^11.0.0");
+    packageJson.updateDependency("@nestjs/platform-express", "^11.1.3");
+    packageJson.updateDependency("@nestjs/cli", "^11.0.7");
+    packageJson.updateDependency("@nestjs/schematics", "^11.0.5");
+    packageJson.updateDependency("@nestjs/testing", "^11.1.3");
 
     packageJson.updateDependency("graphql", "^16.10.0");
 


### PR DESCRIPTION
## Description

Handles the manual change made here: https://github.com/vivid-planet/comet-starter/pull/801. Also updates to `@nestjs/graphql` v13.1.0 to be able to use GraphiQL.