### PR TITLE
Check if isLocalDevelopment by searching for "_npx" in `argv[1]`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ function microserviceExists(microservice: "api" | "admin" | "site") {
     return fs.existsSync(`${microservice}/package.json`);
 }
 
-const isLocalDevelopment = process.argv[0].endsWith("node");
+const isLocalDevelopment = !process.argv[1].includes("_npx");
 const skipLint = process.argv.includes("--skip-lint");
 
 async function main() {


### PR DESCRIPTION
Checking if we are in local development or if the script is executed via npx is hard. I tried multiple versions and none worked. Now I published a [test package](https://www.npmjs.com/package/@thomasdax/test-npx) to actually try this and think this version should actually work. It has following output:

Dev:

```
➜ node index.js
CLI arguments: [
  '/Users/thomasdax/.nvm/versions/node/v22.18.0/bin/node',
  '/Users/thomasdax/dev/vivid/my-package/index.js'
]
npm_exec_path: undefined
Dev
```

Prod:

```
➜ npx @thomasdax/test-npx@latest
Need to install the following packages:
@thomasdax/test-npx@0.0.4
Ok to proceed? (y) y

CLI arguments: [
  '/Users/thomasdax/.nvm/versions/node/v22.18.0/bin/node',
  '/Users/thomasdax/.npm/_npx/3b8560effef20449/node_modules/.bin/test-npx'
]
npm_exec_path: undefined
Prod
```