### PR TITLE
Fix: Restrict imports from comet/admin

### DIFF
--- a/src/v8/admin/after-install/tooltip-1-update-import.ts
+++ b/src/v8/admin/after-install/tooltip-1-update-import.ts
@@ -12,7 +12,7 @@ export default async function updateImportOfTooltip() {
             throw new Error(`Can't get source file for ${filePath}`);
         }
 
-        const adminImport = sourceFile.getImportDeclaration((declaration) => declaration.getModuleSpecifierValue().includes("@comet/admin"));
+        const adminImport = sourceFile.getImportDeclaration((declaration) => declaration.getModuleSpecifierValue() === "@comet/admin");
         const adminImports = adminImport?.getNamedImports().map((namedImport) => namedImport.getText());
 
         if (adminImports) {

--- a/src/v8/admin/after-install/update-import-of-dialog.ts
+++ b/src/v8/admin/after-install/update-import-of-dialog.ts
@@ -12,7 +12,7 @@ export default async function updateImportOfDialog() {
             throw new Error(`Can't get source file for ${filePath}`);
         }
 
-        const adminImport = sourceFile.getImportDeclaration((declaration) => declaration.getModuleSpecifierValue().includes("@comet/admin"));
+        const adminImport = sourceFile.getImportDeclaration((declaration) => declaration.getModuleSpecifierValue() === "@comet/admin");
         const adminImports = adminImport?.getNamedImports().map((namedImport) => namedImport.getText());
 
         if (adminImports) {


### PR DESCRIPTION
Bug: If a file already includes an import from any comet/admin package (e.g. "comet/admin-icons)", this import is also used for importing the `Dialog` component. 


This was caused by a non restrictive declaration of the import source. 

Problem was found and resolved in two update scripts:
- tooltip-1-update-import.ts
- add-dialog-content-to-edit-dialog.ts


| Component to be Updated | Before | After |
| <img width="569" height="260" alt="Bildschirmfoto 2025-09-29 um 15 09 05" src="https://github.com/user-attachments/assets/c64c8145-0a8c-4b85-9552-decab9d1129d" /> | <img width="639" height="273" alt="Bildschirmfoto 2025-09-29 um 15 08 50" src="https://github.com/user-attachments/assets/0c1bb7d6-4940-45fc-a30f-5329b42443d9" /> | <img width="569" height="284" alt="Bildschirmfoto 2025-09-29 um 15 10 00" src="https://github.com/user-attachments/assets/4efcf389-fada-445a-8a05-cfd3d6370497" /> |


